### PR TITLE
feat: add comment line support

### DIFF
--- a/src/ts/ffi.ts
+++ b/src/ts/ffi.ts
@@ -38,6 +38,7 @@ export interface NativeLib {
     escapeChar: number,
     hasHeader: boolean,
     skipEmptyRows: boolean,
+    commentChar: number,
   ) => number | null;
   csv_init_buffer: (data: Uint8Array, len: number) => number | null;
   csv_init_buffer_with_config: (
@@ -48,6 +49,7 @@ export interface NativeLib {
     escapeChar: number,
     hasHeader: boolean,
     skipEmptyRows: boolean,
+    commentChar: number,
   ) => number | null;
   csv_next_row: (handle: number) => boolean;
   csv_get_field_count: (handle: number) => number;
@@ -177,7 +179,7 @@ export function loadNativeLibrary(): NativeLib {
       returns: FFIType.ptr,
     },
     csv_init_with_config: {
-      args: [FFIType.ptr, FFIType.u8, FFIType.u8, FFIType.u8, FFIType.bool, FFIType.bool],
+      args: [FFIType.ptr, FFIType.u8, FFIType.u8, FFIType.u8, FFIType.bool, FFIType.bool, FFIType.u8],
       returns: FFIType.ptr,
     },
     csv_init_buffer: {
@@ -185,7 +187,7 @@ export function loadNativeLibrary(): NativeLib {
       returns: FFIType.ptr,
     },
     csv_init_buffer_with_config: {
-      args: [FFIType.ptr, FFIType.u64, FFIType.u8, FFIType.u8, FFIType.u8, FFIType.bool, FFIType.bool],
+      args: [FFIType.ptr, FFIType.u64, FFIType.u8, FFIType.u8, FFIType.u8, FFIType.bool, FFIType.bool, FFIType.u8],
       returns: FFIType.ptr,
     },
     csv_next_row: {

--- a/src/ts/ffi.ts
+++ b/src/ts/ffi.ts
@@ -31,7 +31,24 @@ export const MAX_BATCH_FIELDS = 64;
 /** Native library symbols */
 export interface NativeLib {
   csv_init: (path: Uint8Array) => number | null;
+  csv_init_with_config: (
+    path: Uint8Array,
+    delimiter: number,
+    quoteChar: number,
+    escapeChar: number,
+    hasHeader: boolean,
+    skipEmptyRows: boolean,
+  ) => number | null;
   csv_init_buffer: (data: Uint8Array, len: number) => number | null;
+  csv_init_buffer_with_config: (
+    data: Uint8Array,
+    len: number,
+    delimiter: number,
+    quoteChar: number,
+    escapeChar: number,
+    hasHeader: boolean,
+    skipEmptyRows: boolean,
+  ) => number | null;
   csv_next_row: (handle: number) => boolean;
   csv_get_field_count: (handle: number) => number;
   csv_get_field_ptr: (handle: number, col: number) => number | null;
@@ -159,8 +176,16 @@ export function loadNativeLibrary(): NativeLib {
       args: [FFIType.ptr],
       returns: FFIType.ptr,
     },
+    csv_init_with_config: {
+      args: [FFIType.ptr, FFIType.u8, FFIType.u8, FFIType.u8, FFIType.bool, FFIType.bool],
+      returns: FFIType.ptr,
+    },
     csv_init_buffer: {
       args: [FFIType.ptr, FFIType.u64],
+      returns: FFIType.ptr,
+    },
+    csv_init_buffer_with_config: {
+      args: [FFIType.ptr, FFIType.u64, FFIType.u8, FFIType.u8, FFIType.u8, FFIType.bool, FFIType.bool],
       returns: FFIType.ptr,
     },
     csv_next_row: {

--- a/test/unit/comments.test.ts
+++ b/test/unit/comments.test.ts
@@ -1,0 +1,149 @@
+/**
+ * Tests for Issue #4: Comment line support
+ */
+
+import { describe, test, expect, beforeAll } from "bun:test";
+import { CSVParser } from "../../src/ts/parser";
+import { writeFileSync } from "fs";
+import { join } from "path";
+
+const TEST_DIR = join(import.meta.dir, "..", "fixtures");
+
+beforeAll(() => {
+  writeFileSync(
+    join(TEST_DIR, "with-hash-comments.csv"),
+    "name,age,city\n# This is a comment\nAlice,30,NYC\n# Another comment\nBob,25,LA\n"
+  );
+
+  writeFileSync(
+    join(TEST_DIR, "with-semicolon-comments.csv"),
+    "name,age\n; comment line\nAlice,30\nBob,25\n"
+  );
+
+  writeFileSync(
+    join(TEST_DIR, "comments-only.csv"),
+    "name,age\n# comment 1\n# comment 2\n# comment 3\n"
+  );
+
+  writeFileSync(
+    join(TEST_DIR, "no-comments.csv"),
+    "name,age\nAlice,30\nBob,25\n"
+  );
+
+  writeFileSync(
+    join(TEST_DIR, "comment-in-field.csv"),
+    'name,note\nAlice,"# not a comment"\nBob,normal\n'
+  );
+});
+
+describe("Comment support", () => {
+  test("skips # comment lines when comments=true", () => {
+    const parser = new CSVParser(join(TEST_DIR, "with-hash-comments.csv"), {
+      comments: true,
+    });
+    const rows: Record<string, string | null>[] = [];
+
+    for (const row of parser) {
+      rows.push(row.toObject());
+    }
+    parser.close();
+
+    expect(rows.length).toBe(2);
+    expect(rows[0]?.name).toBe("Alice");
+    expect(rows[1]?.name).toBe("Bob");
+  });
+
+  test("skips custom comment character", () => {
+    const parser = new CSVParser(join(TEST_DIR, "with-semicolon-comments.csv"), {
+      comments: ";",
+    });
+    const rows: Record<string, string | null>[] = [];
+
+    for (const row of parser) {
+      rows.push(row.toObject());
+    }
+    parser.close();
+
+    expect(rows.length).toBe(2);
+    expect(rows[0]?.name).toBe("Alice");
+    expect(rows[1]?.name).toBe("Bob");
+  });
+
+  test("all comment lines results in no data rows", () => {
+    const parser = new CSVParser(join(TEST_DIR, "comments-only.csv"), {
+      comments: true,
+    });
+    const rows: Record<string, string | null>[] = [];
+
+    for (const row of parser) {
+      rows.push(row.toObject());
+    }
+    parser.close();
+
+    expect(rows.length).toBe(0);
+  });
+
+  test("does not skip comments when comments=false (default)", () => {
+    const parser = new CSVParser(join(TEST_DIR, "with-hash-comments.csv"));
+    let rowCount = 0;
+
+    for (const row of parser) {
+      rowCount++;
+    }
+    parser.close();
+
+    // Without comments option, # lines are treated as data
+    expect(rowCount).toBeGreaterThan(2);
+  });
+
+  test("does not affect file without comments", () => {
+    const parser = new CSVParser(join(TEST_DIR, "no-comments.csv"), {
+      comments: true,
+    });
+    const rows: Record<string, string | null>[] = [];
+
+    for (const row of parser) {
+      rows.push(row.toObject());
+    }
+    parser.close();
+
+    expect(rows.length).toBe(2);
+    expect(rows[0]?.name).toBe("Alice");
+  });
+
+  test("comments work with buffer input", () => {
+    const data = new TextEncoder().encode(
+      "name,age\n# skip this\nAlice,30\n# skip that\nBob,25\n"
+    );
+    const parser = new CSVParser(data, { comments: true });
+    const rows: Record<string, string | null>[] = [];
+
+    for (const row of parser) {
+      rows.push(row.toObject());
+    }
+    parser.close();
+
+    expect(rows.length).toBe(2);
+    expect(rows[0]?.name).toBe("Alice");
+    expect(rows[1]?.name).toBe("Bob");
+  });
+
+  test("comments combined with custom delimiter", () => {
+    const data = new TextEncoder().encode(
+      "name\tage\n# comment\nAlice\t30\nBob\t25\n"
+    );
+    const parser = new CSVParser(data, {
+      delimiter: "\t",
+      comments: "#",
+    });
+    const rows: Record<string, string | null>[] = [];
+
+    for (const row of parser) {
+      rows.push(row.toObject());
+    }
+    parser.close();
+
+    expect(rows.length).toBe(2);
+    expect(rows[0]?.name).toBe("Alice");
+  });
+});

--- a/test/unit/config-wiring.test.ts
+++ b/test/unit/config-wiring.test.ts
@@ -1,0 +1,248 @@
+/**
+ * Tests for Issue #2: Wire existing Zig config options through FFI
+ * Tests: delimiter, escapeChar, skipEmptyRows passing through FFI
+ */
+
+import { describe, test, expect, beforeAll } from "bun:test";
+import { CSVParser } from "../../src/ts/parser";
+import { writeFileSync } from "fs";
+import { join } from "path";
+
+const TEST_DIR = join(import.meta.dir, "..", "fixtures");
+
+beforeAll(() => {
+  // Tab-delimited file
+  writeFileSync(
+    join(TEST_DIR, "tab-delimited.csv"),
+    "name\tage\tcity\nAlice\t30\tNYC\nBob\t25\tLA\n"
+  );
+
+  // Pipe-delimited file
+  writeFileSync(
+    join(TEST_DIR, "pipe-delimited.csv"),
+    "name|age|city\nAlice|30|NYC\nBob|25|LA\n"
+  );
+
+  // Semicolon-delimited file
+  writeFileSync(
+    join(TEST_DIR, "semicolon-delimited.csv"),
+    "name;age;city\nAlice;30;NYC\nBob;25;LA\n"
+  );
+
+  // File with empty rows
+  writeFileSync(
+    join(TEST_DIR, "empty-rows.csv"),
+    "name,age,city\nAlice,30,NYC\n\n\nBob,25,LA\n\nCharlie,35,Chicago\n"
+  );
+
+  // File that is only empty rows
+  writeFileSync(
+    join(TEST_DIR, "all-empty-rows.csv"),
+    "name,age\n\n\n\n"
+  );
+
+  // File with custom escape char (backslash-escaped quotes)
+  writeFileSync(
+    join(TEST_DIR, "custom-escape.csv"),
+    'name,note\nAlice,"says \\"hello\\""\nBob,normal\n'
+  );
+});
+
+describe("Custom delimiter", () => {
+  test("parses tab-delimited file", () => {
+    const parser = new CSVParser(join(TEST_DIR, "tab-delimited.csv"), {
+      delimiter: "\t",
+    });
+    const rows: Record<string, string | null>[] = [];
+
+    for (const row of parser) {
+      rows.push(row.toObject());
+    }
+    parser.close();
+
+    expect(rows.length).toBe(2);
+    expect(rows[0]?.name).toBe("Alice");
+    expect(rows[0]?.age).toBe("30");
+    expect(rows[0]?.city).toBe("NYC");
+    expect(rows[1]?.name).toBe("Bob");
+  });
+
+  test("parses pipe-delimited file", () => {
+    const parser = new CSVParser(join(TEST_DIR, "pipe-delimited.csv"), {
+      delimiter: "|",
+    });
+    const rows: Record<string, string | null>[] = [];
+
+    for (const row of parser) {
+      rows.push(row.toObject());
+    }
+    parser.close();
+
+    expect(rows.length).toBe(2);
+    expect(rows[0]?.name).toBe("Alice");
+    expect(rows[0]?.age).toBe("30");
+  });
+
+  test("parses semicolon-delimited file", () => {
+    const parser = new CSVParser(join(TEST_DIR, "semicolon-delimited.csv"), {
+      delimiter: ";",
+    });
+    const rows: Record<string, string | null>[] = [];
+
+    for (const row of parser) {
+      rows.push(row.toObject());
+    }
+    parser.close();
+
+    expect(rows.length).toBe(2);
+    expect(rows[0]?.name).toBe("Alice");
+    expect(rows[1]?.city).toBe("LA");
+  });
+
+  test("delimiter works with buffer input", () => {
+    const data = new TextEncoder().encode(
+      "name\tage\nAlice\t30\nBob\t25\n"
+    );
+    const parser = new CSVParser(data, { delimiter: "\t" });
+    const rows: Record<string, string | null>[] = [];
+
+    for (const row of parser) {
+      rows.push(row.toObject());
+    }
+    parser.close();
+
+    expect(rows.length).toBe(2);
+    expect(rows[0]?.name).toBe("Alice");
+    expect(rows[0]?.age).toBe("30");
+  });
+});
+
+describe("Skip empty rows", () => {
+  test("skips empty rows by default", () => {
+    const parser = new CSVParser(join(TEST_DIR, "empty-rows.csv"));
+    const rows: Record<string, string | null>[] = [];
+
+    for (const row of parser) {
+      rows.push(row.toObject());
+    }
+    parser.close();
+
+    expect(rows.length).toBe(3);
+    expect(rows[0]?.name).toBe("Alice");
+    expect(rows[1]?.name).toBe("Bob");
+    expect(rows[2]?.name).toBe("Charlie");
+  });
+
+  test("includes empty rows when skipEmptyRows is false", () => {
+    const parser = new CSVParser(join(TEST_DIR, "empty-rows.csv"), {
+      skipEmptyRows: false,
+    });
+    let rowCount = 0;
+
+    for (const row of parser) {
+      rowCount++;
+    }
+    parser.close();
+
+    // Should include the empty rows now (3 data + 3 empty = 6)
+    expect(rowCount).toBeGreaterThan(3);
+  });
+
+  test("handles file with only empty rows", () => {
+    const parser = new CSVParser(join(TEST_DIR, "all-empty-rows.csv"));
+    const rows: Record<string, string | null>[] = [];
+
+    for (const row of parser) {
+      rows.push(row.toObject());
+    }
+    parser.close();
+
+    expect(rows.length).toBe(0);
+  });
+
+  test("skipEmptyRows works with buffer input", () => {
+    const data = new TextEncoder().encode("a,b\n1,2\n\n3,4\n");
+    const parser = new CSVParser(data, { skipEmptyRows: true });
+    const rows: Record<string, string | null>[] = [];
+
+    for (const row of parser) {
+      rows.push(row.toObject());
+    }
+    parser.close();
+
+    expect(rows.length).toBe(2);
+    expect(rows[0]?.a).toBe("1");
+    expect(rows[1]?.a).toBe("3");
+  });
+});
+
+describe("Escape character", () => {
+  test("accepts escapeChar option without error", () => {
+    const parser = new CSVParser(join(TEST_DIR, "tab-delimited.csv"), {
+      delimiter: "\t",
+      escapeChar: '"',
+    });
+    const rows: Record<string, string | null>[] = [];
+
+    for (const row of parser) {
+      rows.push(row.toObject());
+    }
+    parser.close();
+
+    expect(rows.length).toBe(2);
+    expect(rows[0]?.name).toBe("Alice");
+  });
+
+  test("defaults escapeChar to quoteChar", () => {
+    const parser = new CSVParser(join(TEST_DIR, "tab-delimited.csv"), {
+      delimiter: "\t",
+      quoteChar: "'",
+    });
+
+    // Should not throw - escapeChar defaults to quoteChar ("'")
+    const rows: Record<string, string | null>[] = [];
+    for (const row of parser) {
+      rows.push(row.toObject());
+    }
+    parser.close();
+
+    expect(rows.length).toBe(2);
+  });
+});
+
+describe("Combined config options", () => {
+  test("delimiter + skipEmptyRows together", () => {
+    const data = new TextEncoder().encode(
+      "name\tage\nAlice\t30\n\nBob\t25\n"
+    );
+    const parser = new CSVParser(data, {
+      delimiter: "\t",
+      skipEmptyRows: true,
+    });
+    const rows: Record<string, string | null>[] = [];
+
+    for (const row of parser) {
+      rows.push(row.toObject());
+    }
+    parser.close();
+
+    expect(rows.length).toBe(2);
+    expect(rows[0]?.name).toBe("Alice");
+    expect(rows[1]?.name).toBe("Bob");
+  });
+
+  test("hasHeader=false returns all rows as arrays", () => {
+    const data = new TextEncoder().encode("Alice,30,NYC\nBob,25,LA\n");
+    const parser = new CSVParser(data, { hasHeader: false });
+
+    const rows: (string | null)[][] = [];
+    for (const row of parser) {
+      rows.push(row.toArray());
+    }
+    parser.close();
+
+    expect(rows.length).toBe(2);
+    expect(rows[0]?.[0]).toBe("Alice");
+    expect(rows[0]?.[1]).toBe("30");
+  });
+});


### PR DESCRIPTION
## Summary
- Add `comments` option to `CSVParserOptions` to skip lines starting with a comment character
- `comments: true` defaults to `#`, or pass a custom string like `comments: ";"`
- Implemented in Zig parser's `nextRow()` loop for zero-overhead when disabled
- Refactored config resolution into `resolveNativeConfig()` helper

## Test plan
- [x] Skip `#` comment lines with `comments: true`
- [x] Skip custom comment character (`;`)
- [x] All-comment file returns 0 data rows
- [x] No skipping when comments disabled (default)
- [x] No effect on files without comment lines
- [x] Works with buffer input
- [x] Works combined with custom delimiter

All 28 tests pass (21 existing + 7 new).

Closes #4

🤖 Generated with [Claude Code](https://claude.com/claude-code)