### PR TITLE
feat: add preview/row limit option

### DIFF
--- a/src/ts/ffi.ts
+++ b/src/ts/ffi.ts
@@ -38,6 +38,7 @@ export interface NativeLib {
     escapeChar: number,
     hasHeader: boolean,
     skipEmptyRows: boolean,
+    commentChar: number,
   ) => number | null;
   csv_init_buffer: (data: Uint8Array, len: number) => number | null;
   csv_init_buffer_with_config: (
@@ -48,6 +49,7 @@ export interface NativeLib {
     escapeChar: number,
     hasHeader: boolean,
     skipEmptyRows: boolean,
+    commentChar: number,
   ) => number | null;
   csv_next_row: (handle: number) => boolean;
   csv_get_field_count: (handle: number) => number;
@@ -177,7 +179,7 @@ export function loadNativeLibrary(): NativeLib {
       returns: FFIType.ptr,
     },
     csv_init_with_config: {
-      args: [FFIType.ptr, FFIType.u8, FFIType.u8, FFIType.u8, FFIType.bool, FFIType.bool],
+      args: [FFIType.ptr, FFIType.u8, FFIType.u8, FFIType.u8, FFIType.bool, FFIType.bool, FFIType.u8],
       returns: FFIType.ptr,
     },
     csv_init_buffer: {
@@ -185,7 +187,7 @@ export function loadNativeLibrary(): NativeLib {
       returns: FFIType.ptr,
     },
     csv_init_buffer_with_config: {
-      args: [FFIType.ptr, FFIType.u64, FFIType.u8, FFIType.u8, FFIType.u8, FFIType.bool, FFIType.bool],
+      args: [FFIType.ptr, FFIType.u64, FFIType.u8, FFIType.u8, FFIType.u8, FFIType.bool, FFIType.bool, FFIType.u8],
       returns: FFIType.ptr,
     },
     csv_next_row: {

--- a/src/ts/ffi.ts
+++ b/src/ts/ffi.ts
@@ -39,6 +39,7 @@ export interface NativeLib {
     hasHeader: boolean,
     skipEmptyRows: boolean,
     commentChar: number,
+    preview: number,
   ) => number | null;
   csv_init_buffer: (data: Uint8Array, len: number) => number | null;
   csv_init_buffer_with_config: (
@@ -50,6 +51,7 @@ export interface NativeLib {
     hasHeader: boolean,
     skipEmptyRows: boolean,
     commentChar: number,
+    preview: number,
   ) => number | null;
   csv_next_row: (handle: number) => boolean;
   csv_get_field_count: (handle: number) => number;
@@ -179,7 +181,7 @@ export function loadNativeLibrary(): NativeLib {
       returns: FFIType.ptr,
     },
     csv_init_with_config: {
-      args: [FFIType.ptr, FFIType.u8, FFIType.u8, FFIType.u8, FFIType.bool, FFIType.bool, FFIType.u8],
+      args: [FFIType.ptr, FFIType.u8, FFIType.u8, FFIType.u8, FFIType.bool, FFIType.bool, FFIType.u8, FFIType.u64],
       returns: FFIType.ptr,
     },
     csv_init_buffer: {
@@ -187,7 +189,7 @@ export function loadNativeLibrary(): NativeLib {
       returns: FFIType.ptr,
     },
     csv_init_buffer_with_config: {
-      args: [FFIType.ptr, FFIType.u64, FFIType.u8, FFIType.u8, FFIType.u8, FFIType.bool, FFIType.bool, FFIType.u8],
+      args: [FFIType.ptr, FFIType.u64, FFIType.u8, FFIType.u8, FFIType.u8, FFIType.bool, FFIType.bool, FFIType.u8, FFIType.u64],
       returns: FFIType.ptr,
     },
     csv_next_row: {

--- a/src/ts/ffi.ts
+++ b/src/ts/ffi.ts
@@ -31,7 +31,24 @@ export const MAX_BATCH_FIELDS = 64;
 /** Native library symbols */
 export interface NativeLib {
   csv_init: (path: Uint8Array) => number | null;
+  csv_init_with_config: (
+    path: Uint8Array,
+    delimiter: number,
+    quoteChar: number,
+    escapeChar: number,
+    hasHeader: boolean,
+    skipEmptyRows: boolean,
+  ) => number | null;
   csv_init_buffer: (data: Uint8Array, len: number) => number | null;
+  csv_init_buffer_with_config: (
+    data: Uint8Array,
+    len: number,
+    delimiter: number,
+    quoteChar: number,
+    escapeChar: number,
+    hasHeader: boolean,
+    skipEmptyRows: boolean,
+  ) => number | null;
   csv_next_row: (handle: number) => boolean;
   csv_get_field_count: (handle: number) => number;
   csv_get_field_ptr: (handle: number, col: number) => number | null;
@@ -159,8 +176,16 @@ export function loadNativeLibrary(): NativeLib {
       args: [FFIType.ptr],
       returns: FFIType.ptr,
     },
+    csv_init_with_config: {
+      args: [FFIType.ptr, FFIType.u8, FFIType.u8, FFIType.u8, FFIType.bool, FFIType.bool],
+      returns: FFIType.ptr,
+    },
     csv_init_buffer: {
       args: [FFIType.ptr, FFIType.u64],
+      returns: FFIType.ptr,
+    },
+    csv_init_buffer_with_config: {
+      args: [FFIType.ptr, FFIType.u64, FFIType.u8, FFIType.u8, FFIType.u8, FFIType.bool, FFIType.bool],
       returns: FFIType.ptr,
     },
     csv_next_row: {

--- a/src/ts/parser.ts
+++ b/src/ts/parser.ts
@@ -25,6 +25,8 @@ export interface CSVParserOptions<T = Record<string, string>> {
   skipEmptyRows?: boolean;
   /** Skip lines starting with this character (default: false/disabled). Set to true for '#', or a string for custom. */
   comments?: boolean | string;
+  /** Maximum number of data rows to parse (default: 0 = unlimited). Header row is not counted. */
+  preview?: number;
   /** File encoding (default: auto-detect) */
   encoding?: string;
   /** Schema for typed access */
@@ -120,6 +122,7 @@ export class CSVParser<T = Record<string, string>>
       config.hasHeader,
       config.skipEmptyRows,
       config.commentChar,
+      config.preview,
     ) as number;
 
     if (!this.handle) {
@@ -154,6 +157,7 @@ export class CSVParser<T = Record<string, string>>
       config.hasHeader,
       config.skipEmptyRows,
       config.commentChar,
+      config.preview,
     ) as number;
 
     if (!this.handle) {
@@ -525,6 +529,7 @@ export class CSVParser<T = Record<string, string>>
       hasHeader: this.options.hasHeader ?? true,
       skipEmptyRows: this.options.skipEmptyRows ?? true,
       commentChar,
+      preview: this.options.preview ?? 0,
     };
   }
 
@@ -585,6 +590,7 @@ export class CSVParser<T = Record<string, string>>
         config.hasHeader,
         config.skipEmptyRows,
         config.commentChar,
+        config.preview,
       ) as number;
 
       if (!this.handle) {

--- a/test/unit/comments.test.ts
+++ b/test/unit/comments.test.ts
@@ -1,0 +1,149 @@
+/**
+ * Tests for Issue #4: Comment line support
+ */
+
+import { describe, test, expect, beforeAll } from "bun:test";
+import { CSVParser } from "../../src/ts/parser";
+import { writeFileSync } from "fs";
+import { join } from "path";
+
+const TEST_DIR = join(import.meta.dir, "..", "fixtures");
+
+beforeAll(() => {
+  writeFileSync(
+    join(TEST_DIR, "with-hash-comments.csv"),
+    "name,age,city\n# This is a comment\nAlice,30,NYC\n# Another comment\nBob,25,LA\n"
+  );
+
+  writeFileSync(
+    join(TEST_DIR, "with-semicolon-comments.csv"),
+    "name,age\n; comment line\nAlice,30\nBob,25\n"
+  );
+
+  writeFileSync(
+    join(TEST_DIR, "comments-only.csv"),
+    "name,age\n# comment 1\n# comment 2\n# comment 3\n"
+  );
+
+  writeFileSync(
+    join(TEST_DIR, "no-comments.csv"),
+    "name,age\nAlice,30\nBob,25\n"
+  );
+
+  writeFileSync(
+    join(TEST_DIR, "comment-in-field.csv"),
+    'name,note\nAlice,"# not a comment"\nBob,normal\n'
+  );
+});
+
+describe("Comment support", () => {
+  test("skips # comment lines when comments=true", () => {
+    const parser = new CSVParser(join(TEST_DIR, "with-hash-comments.csv"), {
+      comments: true,
+    });
+    const rows: Record<string, string | null>[] = [];
+
+    for (const row of parser) {
+      rows.push(row.toObject());
+    }
+    parser.close();
+
+    expect(rows.length).toBe(2);
+    expect(rows[0]?.name).toBe("Alice");
+    expect(rows[1]?.name).toBe("Bob");
+  });
+
+  test("skips custom comment character", () => {
+    const parser = new CSVParser(join(TEST_DIR, "with-semicolon-comments.csv"), {
+      comments: ";",
+    });
+    const rows: Record<string, string | null>[] = [];
+
+    for (const row of parser) {
+      rows.push(row.toObject());
+    }
+    parser.close();
+
+    expect(rows.length).toBe(2);
+    expect(rows[0]?.name).toBe("Alice");
+    expect(rows[1]?.name).toBe("Bob");
+  });
+
+  test("all comment lines results in no data rows", () => {
+    const parser = new CSVParser(join(TEST_DIR, "comments-only.csv"), {
+      comments: true,
+    });
+    const rows: Record<string, string | null>[] = [];
+
+    for (const row of parser) {
+      rows.push(row.toObject());
+    }
+    parser.close();
+
+    expect(rows.length).toBe(0);
+  });
+
+  test("does not skip comments when comments=false (default)", () => {
+    const parser = new CSVParser(join(TEST_DIR, "with-hash-comments.csv"));
+    let rowCount = 0;
+
+    for (const row of parser) {
+      rowCount++;
+    }
+    parser.close();
+
+    // Without comments option, # lines are treated as data
+    expect(rowCount).toBeGreaterThan(2);
+  });
+
+  test("does not affect file without comments", () => {
+    const parser = new CSVParser(join(TEST_DIR, "no-comments.csv"), {
+      comments: true,
+    });
+    const rows: Record<string, string | null>[] = [];
+
+    for (const row of parser) {
+      rows.push(row.toObject());
+    }
+    parser.close();
+
+    expect(rows.length).toBe(2);
+    expect(rows[0]?.name).toBe("Alice");
+  });
+
+  test("comments work with buffer input", () => {
+    const data = new TextEncoder().encode(
+      "name,age\n# skip this\nAlice,30\n# skip that\nBob,25\n"
+    );
+    const parser = new CSVParser(data, { comments: true });
+    const rows: Record<string, string | null>[] = [];
+
+    for (const row of parser) {
+      rows.push(row.toObject());
+    }
+    parser.close();
+
+    expect(rows.length).toBe(2);
+    expect(rows[0]?.name).toBe("Alice");
+    expect(rows[1]?.name).toBe("Bob");
+  });
+
+  test("comments combined with custom delimiter", () => {
+    const data = new TextEncoder().encode(
+      "name\tage\n# comment\nAlice\t30\nBob\t25\n"
+    );
+    const parser = new CSVParser(data, {
+      delimiter: "\t",
+      comments: "#",
+    });
+    const rows: Record<string, string | null>[] = [];
+
+    for (const row of parser) {
+      rows.push(row.toObject());
+    }
+    parser.close();
+
+    expect(rows.length).toBe(2);
+    expect(rows[0]?.name).toBe("Alice");
+  });
+});

--- a/test/unit/config-wiring.test.ts
+++ b/test/unit/config-wiring.test.ts
@@ -1,0 +1,248 @@
+/**
+ * Tests for Issue #2: Wire existing Zig config options through FFI
+ * Tests: delimiter, escapeChar, skipEmptyRows passing through FFI
+ */
+
+import { describe, test, expect, beforeAll } from "bun:test";
+import { CSVParser } from "../../src/ts/parser";
+import { writeFileSync } from "fs";
+import { join } from "path";
+
+const TEST_DIR = join(import.meta.dir, "..", "fixtures");
+
+beforeAll(() => {
+  // Tab-delimited file
+  writeFileSync(
+    join(TEST_DIR, "tab-delimited.csv"),
+    "name\tage\tcity\nAlice\t30\tNYC\nBob\t25\tLA\n"
+  );
+
+  // Pipe-delimited file
+  writeFileSync(
+    join(TEST_DIR, "pipe-delimited.csv"),
+    "name|age|city\nAlice|30|NYC\nBob|25|LA\n"
+  );
+
+  // Semicolon-delimited file
+  writeFileSync(
+    join(TEST_DIR, "semicolon-delimited.csv"),
+    "name;age;city\nAlice;30;NYC\nBob;25;LA\n"
+  );
+
+  // File with empty rows
+  writeFileSync(
+    join(TEST_DIR, "empty-rows.csv"),
+    "name,age,city\nAlice,30,NYC\n\n\nBob,25,LA\n\nCharlie,35,Chicago\n"
+  );
+
+  // File that is only empty rows
+  writeFileSync(
+    join(TEST_DIR, "all-empty-rows.csv"),
+    "name,age\n\n\n\n"
+  );
+
+  // File with custom escape char (backslash-escaped quotes)
+  writeFileSync(
+    join(TEST_DIR, "custom-escape.csv"),
+    'name,note\nAlice,"says \\"hello\\""\nBob,normal\n'
+  );
+});
+
+describe("Custom delimiter", () => {
+  test("parses tab-delimited file", () => {
+    const parser = new CSVParser(join(TEST_DIR, "tab-delimited.csv"), {
+      delimiter: "\t",
+    });
+    const rows: Record<string, string | null>[] = [];
+
+    for (const row of parser) {
+      rows.push(row.toObject());
+    }
+    parser.close();
+
+    expect(rows.length).toBe(2);
+    expect(rows[0]?.name).toBe("Alice");
+    expect(rows[0]?.age).toBe("30");
+    expect(rows[0]?.city).toBe("NYC");
+    expect(rows[1]?.name).toBe("Bob");
+  });
+
+  test("parses pipe-delimited file", () => {
+    const parser = new CSVParser(join(TEST_DIR, "pipe-delimited.csv"), {
+      delimiter: "|",
+    });
+    const rows: Record<string, string | null>[] = [];
+
+    for (const row of parser) {
+      rows.push(row.toObject());
+    }
+    parser.close();
+
+    expect(rows.length).toBe(2);
+    expect(rows[0]?.name).toBe("Alice");
+    expect(rows[0]?.age).toBe("30");
+  });
+
+  test("parses semicolon-delimited file", () => {
+    const parser = new CSVParser(join(TEST_DIR, "semicolon-delimited.csv"), {
+      delimiter: ";",
+    });
+    const rows: Record<string, string | null>[] = [];
+
+    for (const row of parser) {
+      rows.push(row.toObject());
+    }
+    parser.close();
+
+    expect(rows.length).toBe(2);
+    expect(rows[0]?.name).toBe("Alice");
+    expect(rows[1]?.city).toBe("LA");
+  });
+
+  test("delimiter works with buffer input", () => {
+    const data = new TextEncoder().encode(
+      "name\tage\nAlice\t30\nBob\t25\n"
+    );
+    const parser = new CSVParser(data, { delimiter: "\t" });
+    const rows: Record<string, string | null>[] = [];
+
+    for (const row of parser) {
+      rows.push(row.toObject());
+    }
+    parser.close();
+
+    expect(rows.length).toBe(2);
+    expect(rows[0]?.name).toBe("Alice");
+    expect(rows[0]?.age).toBe("30");
+  });
+});
+
+describe("Skip empty rows", () => {
+  test("skips empty rows by default", () => {
+    const parser = new CSVParser(join(TEST_DIR, "empty-rows.csv"));
+    const rows: Record<string, string | null>[] = [];
+
+    for (const row of parser) {
+      rows.push(row.toObject());
+    }
+    parser.close();
+
+    expect(rows.length).toBe(3);
+    expect(rows[0]?.name).toBe("Alice");
+    expect(rows[1]?.name).toBe("Bob");
+    expect(rows[2]?.name).toBe("Charlie");
+  });
+
+  test("includes empty rows when skipEmptyRows is false", () => {
+    const parser = new CSVParser(join(TEST_DIR, "empty-rows.csv"), {
+      skipEmptyRows: false,
+    });
+    let rowCount = 0;
+
+    for (const row of parser) {
+      rowCount++;
+    }
+    parser.close();
+
+    // Should include the empty rows now (3 data + 3 empty = 6)
+    expect(rowCount).toBeGreaterThan(3);
+  });
+
+  test("handles file with only empty rows", () => {
+    const parser = new CSVParser(join(TEST_DIR, "all-empty-rows.csv"));
+    const rows: Record<string, string | null>[] = [];
+
+    for (const row of parser) {
+      rows.push(row.toObject());
+    }
+    parser.close();
+
+    expect(rows.length).toBe(0);
+  });
+
+  test("skipEmptyRows works with buffer input", () => {
+    const data = new TextEncoder().encode("a,b\n1,2\n\n3,4\n");
+    const parser = new CSVParser(data, { skipEmptyRows: true });
+    const rows: Record<string, string | null>[] = [];
+
+    for (const row of parser) {
+      rows.push(row.toObject());
+    }
+    parser.close();
+
+    expect(rows.length).toBe(2);
+    expect(rows[0]?.a).toBe("1");
+    expect(rows[1]?.a).toBe("3");
+  });
+});
+
+describe("Escape character", () => {
+  test("accepts escapeChar option without error", () => {
+    const parser = new CSVParser(join(TEST_DIR, "tab-delimited.csv"), {
+      delimiter: "\t",
+      escapeChar: '"',
+    });
+    const rows: Record<string, string | null>[] = [];
+
+    for (const row of parser) {
+      rows.push(row.toObject());
+    }
+    parser.close();
+
+    expect(rows.length).toBe(2);
+    expect(rows[0]?.name).toBe("Alice");
+  });
+
+  test("defaults escapeChar to quoteChar", () => {
+    const parser = new CSVParser(join(TEST_DIR, "tab-delimited.csv"), {
+      delimiter: "\t",
+      quoteChar: "'",
+    });
+
+    // Should not throw - escapeChar defaults to quoteChar ("'")
+    const rows: Record<string, string | null>[] = [];
+    for (const row of parser) {
+      rows.push(row.toObject());
+    }
+    parser.close();
+
+    expect(rows.length).toBe(2);
+  });
+});
+
+describe("Combined config options", () => {
+  test("delimiter + skipEmptyRows together", () => {
+    const data = new TextEncoder().encode(
+      "name\tage\nAlice\t30\n\nBob\t25\n"
+    );
+    const parser = new CSVParser(data, {
+      delimiter: "\t",
+      skipEmptyRows: true,
+    });
+    const rows: Record<string, string | null>[] = [];
+
+    for (const row of parser) {
+      rows.push(row.toObject());
+    }
+    parser.close();
+
+    expect(rows.length).toBe(2);
+    expect(rows[0]?.name).toBe("Alice");
+    expect(rows[1]?.name).toBe("Bob");
+  });
+
+  test("hasHeader=false returns all rows as arrays", () => {
+    const data = new TextEncoder().encode("Alice,30,NYC\nBob,25,LA\n");
+    const parser = new CSVParser(data, { hasHeader: false });
+
+    const rows: (string | null)[][] = [];
+    for (const row of parser) {
+      rows.push(row.toArray());
+    }
+    parser.close();
+
+    expect(rows.length).toBe(2);
+    expect(rows[0]?.[0]).toBe("Alice");
+    expect(rows[0]?.[1]).toBe("30");
+  });
+});

--- a/test/unit/preview.test.ts
+++ b/test/unit/preview.test.ts
@@ -1,0 +1,159 @@
+/**
+ * Tests for Issue #5: Preview / row limit support
+ */
+
+import { describe, test, expect, beforeAll } from "bun:test";
+import { CSVParser } from "../../src/ts/parser";
+import { writeFileSync } from "fs";
+import { join } from "path";
+
+const TEST_DIR = join(import.meta.dir, "..", "fixtures");
+
+beforeAll(() => {
+  writeFileSync(
+    join(TEST_DIR, "ten-rows.csv"),
+    "name,age,city\nAlice,30,NYC\nBob,25,LA\nCharlie,35,Chicago\nDiana,28,Seattle\nEve,32,Boston\nFrank,29,Denver\nGrace,31,Miami\nHank,27,Austin\nIvy,33,Portland\nJack,26,Dallas\n"
+  );
+});
+
+describe("Preview / row limit", () => {
+  test("preview=3 returns only first 3 data rows from file", () => {
+    const parser = new CSVParser(join(TEST_DIR, "ten-rows.csv"), {
+      preview: 3,
+    });
+    const rows: Record<string, string | null>[] = [];
+
+    for (const row of parser) {
+      rows.push(row.toObject());
+    }
+    parser.close();
+
+    expect(rows.length).toBe(3);
+    expect(rows[0]?.name).toBe("Alice");
+    expect(rows[1]?.name).toBe("Bob");
+    expect(rows[2]?.name).toBe("Charlie");
+  });
+
+  test("preview=1 returns only the first data row", () => {
+    const parser = new CSVParser(join(TEST_DIR, "ten-rows.csv"), {
+      preview: 1,
+    });
+    const rows: Record<string, string | null>[] = [];
+
+    for (const row of parser) {
+      rows.push(row.toObject());
+    }
+    parser.close();
+
+    expect(rows.length).toBe(1);
+    expect(rows[0]?.name).toBe("Alice");
+  });
+
+  test("preview larger than row count returns all rows", () => {
+    const parser = new CSVParser(join(TEST_DIR, "ten-rows.csv"), {
+      preview: 100,
+    });
+    const rows: Record<string, string | null>[] = [];
+
+    for (const row of parser) {
+      rows.push(row.toObject());
+    }
+    parser.close();
+
+    expect(rows.length).toBe(10);
+  });
+
+  test("preview=0 (default) returns all rows", () => {
+    const parser = new CSVParser(join(TEST_DIR, "ten-rows.csv"), {
+      preview: 0,
+    });
+    const rows: Record<string, string | null>[] = [];
+
+    for (const row of parser) {
+      rows.push(row.toObject());
+    }
+    parser.close();
+
+    expect(rows.length).toBe(10);
+  });
+
+  test("no preview option returns all rows", () => {
+    const parser = new CSVParser(join(TEST_DIR, "ten-rows.csv"));
+    const rows: Record<string, string | null>[] = [];
+
+    for (const row of parser) {
+      rows.push(row.toObject());
+    }
+    parser.close();
+
+    expect(rows.length).toBe(10);
+  });
+
+  test("preview works with buffer input", () => {
+    const data = new TextEncoder().encode(
+      "name,age\nAlice,30\nBob,25\nCharlie,35\nDiana,28\nEve,32\n"
+    );
+    const parser = new CSVParser(data, { preview: 2 });
+    const rows: Record<string, string | null>[] = [];
+
+    for (const row of parser) {
+      rows.push(row.toObject());
+    }
+    parser.close();
+
+    expect(rows.length).toBe(2);
+    expect(rows[0]?.name).toBe("Alice");
+    expect(rows[1]?.name).toBe("Bob");
+  });
+
+  test("preview combined with comments skips comment lines correctly", () => {
+    const data = new TextEncoder().encode(
+      "name,age\n# comment\nAlice,30\n# comment\nBob,25\nCharlie,35\nDiana,28\n"
+    );
+    const parser = new CSVParser(data, { preview: 2, comments: true });
+    const rows: Record<string, string | null>[] = [];
+
+    for (const row of parser) {
+      rows.push(row.toObject());
+    }
+    parser.close();
+
+    expect(rows.length).toBe(2);
+    expect(rows[0]?.name).toBe("Alice");
+    expect(rows[1]?.name).toBe("Bob");
+  });
+
+  test("preview combined with custom delimiter", () => {
+    const data = new TextEncoder().encode(
+      "name\tage\nAlice\t30\nBob\t25\nCharlie\t35\n"
+    );
+    const parser = new CSVParser(data, { delimiter: "\t", preview: 2 });
+    const rows: Record<string, string | null>[] = [];
+
+    for (const row of parser) {
+      rows.push(row.toObject());
+    }
+    parser.close();
+
+    expect(rows.length).toBe(2);
+    expect(rows[0]?.name).toBe("Alice");
+    expect(rows[1]?.name).toBe("Bob");
+  });
+
+  test("preview combined with skipEmptyRows", () => {
+    const data = new TextEncoder().encode(
+      "name,age\n\nAlice,30\n\nBob,25\n\nCharlie,35\n"
+    );
+    const parser = new CSVParser(data, { preview: 2, skipEmptyRows: true });
+    const rows: Record<string, string | null>[] = [];
+
+    for (const row of parser) {
+      rows.push(row.toObject());
+    }
+    parser.close();
+
+    expect(rows.length).toBe(2);
+    expect(rows[0]?.name).toBe("Alice");
+    expect(rows[1]?.name).toBe("Bob");
+  });
+});


### PR DESCRIPTION
## Summary
- Adds `preview` option to `CSVParserOptions` that limits parsing to N data rows (header not counted)
- Wired through Zig FFI: `preview` parameter added to `csv_init_with_config` and `csv_init_buffer_with_config`
- Preview check in Zig `nextRow()` closes parser after emitting the configured number of data rows
- 9 new tests covering file input, buffer input, and combinations with comments/delimiter/skipEmptyRows

Closes #5

## Test plan
- [x] `preview=3` returns exactly 3 data rows from a 10-row file
- [x] `preview=1` returns only the first data row
- [x] `preview` larger than row count returns all rows
- [x] `preview=0` (default) returns all rows
- [x] No preview option returns all rows
- [x] Preview works with buffer input
- [x] Preview combined with comments
- [x] Preview combined with custom delimiter
- [x] Preview combined with skipEmptyRows
- [x] All 37 existing tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)