### PR TITLE
feat: add skipFirstNLines option

### DIFF
--- a/src/ts/ffi.ts
+++ b/src/ts/ffi.ts
@@ -40,6 +40,7 @@ export interface NativeLib {
     skipEmptyRows: boolean,
     commentChar: number,
     preview: number,
+    skipFirstNLines: number,
   ) => number | null;
   csv_init_buffer: (data: Uint8Array, len: number) => number | null;
   csv_init_buffer_with_config: (
@@ -52,6 +53,7 @@ export interface NativeLib {
     skipEmptyRows: boolean,
     commentChar: number,
     preview: number,
+    skipFirstNLines: number,
   ) => number | null;
   csv_next_row: (handle: number) => boolean;
   csv_get_field_count: (handle: number) => number;
@@ -181,7 +183,7 @@ export function loadNativeLibrary(): NativeLib {
       returns: FFIType.ptr,
     },
     csv_init_with_config: {
-      args: [FFIType.ptr, FFIType.u8, FFIType.u8, FFIType.u8, FFIType.bool, FFIType.bool, FFIType.u8, FFIType.u64],
+      args: [FFIType.ptr, FFIType.u8, FFIType.u8, FFIType.u8, FFIType.bool, FFIType.bool, FFIType.u8, FFIType.u64, FFIType.u64],
       returns: FFIType.ptr,
     },
     csv_init_buffer: {
@@ -189,7 +191,7 @@ export function loadNativeLibrary(): NativeLib {
       returns: FFIType.ptr,
     },
     csv_init_buffer_with_config: {
-      args: [FFIType.ptr, FFIType.u64, FFIType.u8, FFIType.u8, FFIType.u8, FFIType.bool, FFIType.bool, FFIType.u8, FFIType.u64],
+      args: [FFIType.ptr, FFIType.u64, FFIType.u8, FFIType.u8, FFIType.u8, FFIType.bool, FFIType.bool, FFIType.u8, FFIType.u64, FFIType.u64],
       returns: FFIType.ptr,
     },
     csv_next_row: {

--- a/src/ts/parser.ts
+++ b/src/ts/parser.ts
@@ -27,6 +27,8 @@ export interface CSVParserOptions<T = Record<string, string>> {
   comments?: boolean | string;
   /** Maximum number of data rows to parse (default: 0 = unlimited). Header row is not counted. */
   preview?: number;
+  /** Number of raw lines to skip before parsing begins (default: 0). Useful for files with metadata preambles. */
+  skipFirstNLines?: number;
   /** File encoding (default: auto-detect) */
   encoding?: string;
   /** Schema for typed access */
@@ -123,6 +125,7 @@ export class CSVParser<T = Record<string, string>>
       config.skipEmptyRows,
       config.commentChar,
       config.preview,
+      config.skipFirstNLines,
     ) as number;
 
     if (!this.handle) {
@@ -158,6 +161,7 @@ export class CSVParser<T = Record<string, string>>
       config.skipEmptyRows,
       config.commentChar,
       config.preview,
+      config.skipFirstNLines,
     ) as number;
 
     if (!this.handle) {
@@ -530,6 +534,7 @@ export class CSVParser<T = Record<string, string>>
       skipEmptyRows: this.options.skipEmptyRows ?? true,
       commentChar,
       preview: this.options.preview ?? 0,
+      skipFirstNLines: this.options.skipFirstNLines ?? 0,
     };
   }
 
@@ -591,6 +596,7 @@ export class CSVParser<T = Record<string, string>>
         config.skipEmptyRows,
         config.commentChar,
         config.preview,
+        config.skipFirstNLines,
       ) as number;
 
       if (!this.handle) {

--- a/test/unit/skip-first-n-lines.test.ts
+++ b/test/unit/skip-first-n-lines.test.ts
@@ -1,0 +1,157 @@
+/**
+ * Tests for Issue #13: skipFirstNLines option
+ */
+
+import { describe, test, expect, beforeAll } from "bun:test";
+import { CSVParser } from "../../src/ts/parser";
+import { writeFileSync } from "fs";
+import { join } from "path";
+
+const TEST_DIR = join(import.meta.dir, "..", "fixtures");
+
+beforeAll(() => {
+  // File with metadata preamble
+  writeFileSync(
+    join(TEST_DIR, "with-preamble.csv"),
+    "Generated: 2024-01-01\nSource: System Export\nname,age,city\nAlice,30,NYC\nBob,25,LA\n"
+  );
+
+  // File with single metadata line
+  writeFileSync(
+    join(TEST_DIR, "single-meta-line.csv"),
+    "# Report generated 2024\nname,age\nAlice,30\nBob,25\n"
+  );
+});
+
+describe("skipFirstNLines", () => {
+  test("skip 2 metadata lines before header", () => {
+    const parser = new CSVParser(join(TEST_DIR, "with-preamble.csv"), {
+      skipFirstNLines: 2,
+    });
+    const rows: Record<string, string | null>[] = [];
+
+    for (const row of parser) {
+      rows.push(row.toObject());
+    }
+    parser.close();
+
+    expect(rows.length).toBe(2);
+    expect(rows[0]?.name).toBe("Alice");
+    expect(rows[0]?.age).toBe("30");
+    expect(rows[1]?.name).toBe("Bob");
+  });
+
+  test("skip 1 metadata line", () => {
+    const parser = new CSVParser(join(TEST_DIR, "single-meta-line.csv"), {
+      skipFirstNLines: 1,
+    });
+    const rows: Record<string, string | null>[] = [];
+
+    for (const row of parser) {
+      rows.push(row.toObject());
+    }
+    parser.close();
+
+    expect(rows.length).toBe(2);
+    expect(rows[0]?.name).toBe("Alice");
+    expect(rows[1]?.name).toBe("Bob");
+  });
+
+  test("skip 0 lines (default) parses everything", () => {
+    const parser = new CSVParser(join(TEST_DIR, "single-meta-line.csv"), {
+      skipFirstNLines: 0,
+    });
+    let rowCount = 0;
+
+    for (const row of parser) {
+      rowCount++;
+    }
+    parser.close();
+
+    // Header is "# Report generated 2024", data rows include "name,age", "Alice,30", "Bob,25"
+    expect(rowCount).toBe(3);
+  });
+
+  test("no skipFirstNLines option parses everything", () => {
+    const parser = new CSVParser(join(TEST_DIR, "single-meta-line.csv"));
+    let rowCount = 0;
+
+    for (const row of parser) {
+      rowCount++;
+    }
+    parser.close();
+
+    expect(rowCount).toBe(3);
+  });
+
+  test("skip more lines than file has returns no rows", () => {
+    const parser = new CSVParser(join(TEST_DIR, "single-meta-line.csv"), {
+      skipFirstNLines: 100,
+    });
+    const rows: Record<string, string | null>[] = [];
+
+    for (const row of parser) {
+      rows.push(row.toObject());
+    }
+    parser.close();
+
+    expect(rows.length).toBe(0);
+  });
+
+  test("skipFirstNLines works with buffer input", () => {
+    const data = new TextEncoder().encode(
+      "metadata line 1\nmetadata line 2\nname,age\nAlice,30\nBob,25\n"
+    );
+    const parser = new CSVParser(data, { skipFirstNLines: 2 });
+    const rows: Record<string, string | null>[] = [];
+
+    for (const row of parser) {
+      rows.push(row.toObject());
+    }
+    parser.close();
+
+    expect(rows.length).toBe(2);
+    expect(rows[0]?.name).toBe("Alice");
+    expect(rows[1]?.name).toBe("Bob");
+  });
+
+  test("skipFirstNLines combined with custom delimiter", () => {
+    const data = new TextEncoder().encode(
+      "preamble\nname\tage\nAlice\t30\nBob\t25\n"
+    );
+    const parser = new CSVParser(data, {
+      skipFirstNLines: 1,
+      delimiter: "\t",
+    });
+    const rows: Record<string, string | null>[] = [];
+
+    for (const row of parser) {
+      rows.push(row.toObject());
+    }
+    parser.close();
+
+    expect(rows.length).toBe(2);
+    expect(rows[0]?.name).toBe("Alice");
+    expect(rows[0]?.age).toBe("30");
+  });
+
+  test("skipFirstNLines combined with comments", () => {
+    const data = new TextEncoder().encode(
+      "preamble\nname,age\n# comment\nAlice,30\nBob,25\n"
+    );
+    const parser = new CSVParser(data, {
+      skipFirstNLines: 1,
+      comments: true,
+    });
+    const rows: Record<string, string | null>[] = [];
+
+    for (const row of parser) {
+      rows.push(row.toObject());
+    }
+    parser.close();
+
+    expect(rows.length).toBe(2);
+    expect(rows[0]?.name).toBe("Alice");
+    expect(rows[1]?.name).toBe("Bob");
+  });
+});


### PR DESCRIPTION
## Summary
- Adds `skipFirstNLines` option to `CSVParserOptions` for skipping metadata preamble lines before CSV parsing begins
- Implemented at the Zig parser init level — cursor advances past N newlines before any `nextRow()` calls
- Zero overhead when not configured (default: 0)
- Wired through FFI with `skip_first_n_lines` parameter on both `csv_init_with_config` and `csv_init_buffer_with_config`
- 8 new tests covering file input, buffer input, edge cases, and combinations

Closes #13

## Test plan
- [x] Skip 2 metadata lines before header
- [x] Skip 1 metadata line
- [x] Skip 0 (default) parses everything
- [x] No option set parses everything
- [x] Skip more lines than file has returns no rows
- [x] Works with buffer input
- [x] Combined with custom delimiter
- [x] Combined with comments
- [x] All 36 existing tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)