### PR TITLE
feat: implement delimiter auto-detection

### DIFF
--- a/src/ts/ffi.ts
+++ b/src/ts/ffi.ts
@@ -106,6 +106,8 @@ export interface NativeLib {
   // Encoding
   csv_detect_encoding: (data: Uint8Array, len: number) => number;
   csv_detect_bom: (data: Uint8Array, len: number) => number;
+  // Delimiter detection
+  csv_detect_delimiter: (data: Uint8Array, len: number, candidates: Uint8Array | null, numCandidates: number, quoteChar: number) => number;
 }
 
 /** Library handle singleton */
@@ -385,6 +387,11 @@ export function loadNativeLibrary(): NativeLib {
     csv_detect_bom: {
       args: [FFIType.ptr, FFIType.u64],
       returns: FFIType.u64,
+    },
+    // Delimiter detection
+    csv_detect_delimiter: {
+      args: [FFIType.ptr, FFIType.u64, FFIType.ptr, FFIType.u64, FFIType.u8],
+      returns: FFIType.u8,
     },
   });
 

--- a/src/ts/ffi.ts
+++ b/src/ts/ffi.ts
@@ -38,6 +38,7 @@ export interface NativeLib {
     escapeChar: number,
     hasHeader: boolean,
     skipEmptyRows: boolean,
+    commentChar: number,
   ) => number | null;
   csv_init_buffer: (data: Uint8Array, len: number) => number | null;
   csv_init_buffer_with_config: (
@@ -48,6 +49,7 @@ export interface NativeLib {
     escapeChar: number,
     hasHeader: boolean,
     skipEmptyRows: boolean,
+    commentChar: number,
   ) => number | null;
   csv_next_row: (handle: number) => boolean;
   csv_get_field_count: (handle: number) => number;
@@ -177,7 +179,7 @@ export function loadNativeLibrary(): NativeLib {
       returns: FFIType.ptr,
     },
     csv_init_with_config: {
-      args: [FFIType.ptr, FFIType.u8, FFIType.u8, FFIType.u8, FFIType.bool, FFIType.bool],
+      args: [FFIType.ptr, FFIType.u8, FFIType.u8, FFIType.u8, FFIType.bool, FFIType.bool, FFIType.u8],
       returns: FFIType.ptr,
     },
     csv_init_buffer: {
@@ -185,7 +187,7 @@ export function loadNativeLibrary(): NativeLib {
       returns: FFIType.ptr,
     },
     csv_init_buffer_with_config: {
-      args: [FFIType.ptr, FFIType.u64, FFIType.u8, FFIType.u8, FFIType.u8, FFIType.bool, FFIType.bool],
+      args: [FFIType.ptr, FFIType.u64, FFIType.u8, FFIType.u8, FFIType.u8, FFIType.bool, FFIType.bool, FFIType.u8],
       returns: FFIType.ptr,
     },
     csv_next_row: {

--- a/src/ts/ffi.ts
+++ b/src/ts/ffi.ts
@@ -31,7 +31,24 @@ export const MAX_BATCH_FIELDS = 64;
 /** Native library symbols */
 export interface NativeLib {
   csv_init: (path: Uint8Array) => number | null;
+  csv_init_with_config: (
+    path: Uint8Array,
+    delimiter: number,
+    quoteChar: number,
+    escapeChar: number,
+    hasHeader: boolean,
+    skipEmptyRows: boolean,
+  ) => number | null;
   csv_init_buffer: (data: Uint8Array, len: number) => number | null;
+  csv_init_buffer_with_config: (
+    data: Uint8Array,
+    len: number,
+    delimiter: number,
+    quoteChar: number,
+    escapeChar: number,
+    hasHeader: boolean,
+    skipEmptyRows: boolean,
+  ) => number | null;
   csv_next_row: (handle: number) => boolean;
   csv_get_field_count: (handle: number) => number;
   csv_get_field_ptr: (handle: number, col: number) => number | null;
@@ -159,8 +176,16 @@ export function loadNativeLibrary(): NativeLib {
       args: [FFIType.ptr],
       returns: FFIType.ptr,
     },
+    csv_init_with_config: {
+      args: [FFIType.ptr, FFIType.u8, FFIType.u8, FFIType.u8, FFIType.bool, FFIType.bool],
+      returns: FFIType.ptr,
+    },
     csv_init_buffer: {
       args: [FFIType.ptr, FFIType.u64],
+      returns: FFIType.ptr,
+    },
+    csv_init_buffer_with_config: {
+      args: [FFIType.ptr, FFIType.u64, FFIType.u8, FFIType.u8, FFIType.u8, FFIType.bool, FFIType.bool],
       returns: FFIType.ptr,
     },
     csv_next_row: {

--- a/src/ts/parser.ts
+++ b/src/ts/parser.ts
@@ -4,6 +4,7 @@
 
 import { loadNativeLibrary, toCString, isNativeAvailable, CacheLimitStatus, Encoding } from "./ffi";
 import { toArrayBuffer, type Pointer } from "bun:ffi";
+import { readFileSync } from "fs";
 import { CSVRow } from "./row";
 import { DataFrame } from "./dataframe";
 import { CSVWriter, ModificationLog } from "./writer";
@@ -13,8 +14,10 @@ export { CacheLimitStatus, Encoding };
 
 /** Parser options */
 export interface CSVParserOptions<T = Record<string, string>> {
-  /** Field delimiter (default: ",") */
+  /** Field delimiter. Set to "auto" for auto-detection (default: ",") */
   delimiter?: string;
+  /** Candidate delimiters for auto-detection (default: [",", "\t", "|", ";"]) */
+  delimitersToGuess?: string[];
   /** Quote character (default: ") */
   quoteChar?: string;
   /** Escape character for quotes (default: same as quoteChar) */
@@ -86,6 +89,11 @@ export class CSVParser<T = Record<string, string>>
     if (options.writable) {
       this.modifications = new ModificationLog();
       this.cachedRows = new Map();
+    }
+
+    // Auto-detect delimiter if requested
+    if (this.options.delimiter === "auto") {
+      this.options.delimiter = this.autoDetectDelimiter(source);
     }
 
     // Initialize immediately for file paths
@@ -526,6 +534,52 @@ export class CSVParser<T = Record<string, string>>
       skipEmptyRows: this.options.skipEmptyRows ?? true,
       commentChar,
     };
+  }
+
+  /**
+   * Auto-detect delimiter by sampling data and testing candidates.
+   * Returns the detected single-character delimiter string.
+   */
+  private autoDetectDelimiter(source: InputSource): string {
+    const lib = loadNativeLibrary();
+
+    // Get sample data
+    let sample: Uint8Array;
+    if (typeof source === "string" && !source.startsWith("http")) {
+      // Read first 8KB of file for detection
+      const fullBuf = readFileSync(source);
+      sample = fullBuf.length > 8192 ? fullBuf.subarray(0, 8192) : fullBuf;
+    } else if (source instanceof Uint8Array) {
+      sample = source.length > 8192 ? source.subarray(0, 8192) : source;
+    } else if (source instanceof ArrayBuffer) {
+      const view = new Uint8Array(source);
+      sample = view.length > 8192 ? view.subarray(0, 8192) : view;
+    } else {
+      return ","; // Fallback for streams
+    }
+
+    // Build candidates array
+    const guesses = this.options.delimitersToGuess;
+    let candidatesArray = new Uint8Array(1); // dummy, ignored when numCandidates=0
+    let numCandidates = 0;
+    if (guesses && guesses.length > 0) {
+      candidatesArray = new Uint8Array(guesses.length);
+      for (let i = 0; i < guesses.length; i++) {
+        candidatesArray[i] = guesses[i]!.charCodeAt(0);
+      }
+      numCandidates = guesses.length;
+    }
+
+    const quoteChar = (this.options.quoteChar ?? '"').charCodeAt(0);
+    const detected = lib.csv_detect_delimiter(
+      sample,
+      sample.length,
+      candidatesArray,
+      numCandidates,
+      quoteChar,
+    ) as number;
+
+    return String.fromCharCode(detected);
   }
 
   /**

--- a/src/zig/detect.zig
+++ b/src/zig/detect.zig
@@ -1,0 +1,176 @@
+const std = @import("std");
+
+/// Default candidate delimiters to test
+pub const DEFAULT_CANDIDATES = [_]u8{ ',', '\t', '|', ';' };
+
+/// Maximum number of rows to sample for detection
+const MAX_SAMPLE_ROWS = 10;
+
+/// Maximum number of candidate delimiters
+pub const MAX_CANDIDATES = 16;
+
+/// Result of delimiter detection
+pub const DetectResult = struct {
+    delimiter: u8,
+    confidence: f32, // 0.0 to 1.0
+};
+
+/// Detect the most likely delimiter in CSV data by sampling the first few rows.
+///
+/// Algorithm: For each candidate delimiter, count how many fields each sample
+/// row produces. The best delimiter is the one that gives the most consistent
+/// field count across rows AND produces more than 1 field on average.
+///
+/// Parameters:
+///   data: the raw CSV bytes
+///   data_len: length of data
+///   candidates: array of delimiter bytes to test
+///   num_candidates: how many candidates to test
+///   quote_char: the quote character (to handle quoted fields correctly)
+///
+/// Returns the detected delimiter byte, or ',' as fallback.
+pub fn detectDelimiter(
+    data: []const u8,
+    candidates: []const u8,
+    quote_char: u8,
+) DetectResult {
+    if (data.len == 0) {
+        return .{ .delimiter = ',', .confidence = 0.0 };
+    }
+
+    var best_delimiter: u8 = ',';
+    var best_score: f32 = -1.0;
+
+    for (candidates) |candidate| {
+        const score = scoreCandidate(data, candidate, quote_char);
+        if (score > best_score) {
+            best_score = score;
+            best_delimiter = candidate;
+        }
+    }
+
+    return .{
+        .delimiter = best_delimiter,
+        .confidence = if (best_score > 0) @min(best_score / 10.0, 1.0) else 0.0,
+    };
+}
+
+/// Score a candidate delimiter. Higher is better.
+/// Score = average_fields * consistency_factor
+/// consistency_factor = 1.0 if all rows have the same field count, lower otherwise
+fn scoreCandidate(data: []const u8, delimiter: u8, quote_char: u8) f32 {
+    var field_counts: [MAX_SAMPLE_ROWS]usize = undefined;
+    var row_count: usize = 0;
+
+    var cursor: usize = 0;
+
+    while (row_count < MAX_SAMPLE_ROWS and cursor < data.len) {
+        // Count fields in this row
+        var fields: usize = 1; // At least one field per row
+        var in_quote = false;
+
+
+        while (cursor < data.len) {
+            const ch = data[cursor];
+
+            if (in_quote) {
+                if (ch == quote_char) {
+                    // Check for escaped quote (doubled)
+                    if (cursor + 1 < data.len and data[cursor + 1] == quote_char) {
+                        cursor += 2;
+                        continue;
+                    }
+                    in_quote = false;
+                }
+            } else {
+                if (ch == quote_char) {
+                    in_quote = true;
+                } else if (ch == delimiter) {
+                    fields += 1;
+                } else if (ch == '\n') {
+                    cursor += 1;
+                    break;
+                } else if (ch == '\r') {
+                    cursor += 1;
+                    if (cursor < data.len and data[cursor] == '\n') {
+                        cursor += 1;
+                    }
+                    break;
+                }
+            }
+            cursor += 1;
+        }
+
+        field_counts[row_count] = fields;
+        row_count += 1;
+    }
+
+    if (row_count == 0) {
+        return 0.0;
+    }
+
+    // Calculate average field count
+    var total_fields: usize = 0;
+    for (0..row_count) |i| {
+        total_fields += field_counts[i];
+    }
+    const avg_fields: f32 = @as(f32, @floatFromInt(total_fields)) / @as(f32, @floatFromInt(row_count));
+
+    // If average is <= 1.0, this delimiter doesn't split anything useful
+    if (avg_fields <= 1.0) {
+        return 0.0;
+    }
+
+    // Calculate consistency: what fraction of rows match the most common field count
+    // Find mode (most common field count)
+    var mode_count: usize = 0;
+    for (0..row_count) |i| {
+        var count: usize = 0;
+        for (0..row_count) |j| {
+            if (field_counts[j] == field_counts[i]) {
+                count += 1;
+            }
+        }
+        if (count > mode_count) {
+            mode_count = count;
+        }
+    }
+
+    const consistency: f32 = @as(f32, @floatFromInt(mode_count)) / @as(f32, @floatFromInt(row_count));
+
+    // Score = avg_fields * consistency
+    // This rewards delimiters that produce many fields consistently
+    return avg_fields * consistency;
+}
+
+test "detect comma delimiter" {
+    const data = "name,age,city\nAlice,30,NYC\nBob,25,LA\n";
+    const result = detectDelimiter(data, &DEFAULT_CANDIDATES, '"');
+    try std.testing.expectEqual(@as(u8, ','), result.delimiter);
+}
+
+test "detect tab delimiter" {
+    const data = "name\tage\tcity\nAlice\t30\tNYC\nBob\t25\tLA\n";
+    const result = detectDelimiter(data, &DEFAULT_CANDIDATES, '"');
+    try std.testing.expectEqual(@as(u8, '\t'), result.delimiter);
+}
+
+test "detect pipe delimiter" {
+    const data = "name|age|city\nAlice|30|NYC\nBob|25|LA\n";
+    const result = detectDelimiter(data, &DEFAULT_CANDIDATES, '"');
+    try std.testing.expectEqual(@as(u8, '|'), result.delimiter);
+}
+
+test "detect semicolon delimiter" {
+    const data = "name;age;city\nAlice;30;NYC\nBob;25;LA\n";
+    const result = detectDelimiter(data, &DEFAULT_CANDIDATES, '"');
+    try std.testing.expectEqual(@as(u8, ';'), result.delimiter);
+}
+
+test "single column falls back to comma" {
+    const data = "name\nAlice\nBob\n";
+    const result = detectDelimiter(data, &DEFAULT_CANDIDATES, '"');
+    // With single column, no delimiter produces >1 field, so score is 0 for all.
+    // Fallback is comma (first tested, or initial best).
+    try std.testing.expectEqual(@as(u8, ','), result.delimiter);
+}

--- a/src/zig/parser.zig
+++ b/src/zig/parser.zig
@@ -4,6 +4,7 @@ const simd = @import("simd.zig");
 const iconv = @import("iconv.zig");
 const mmap = @import("mmap.zig");
 pub const dataframe = @import("dataframe.zig");
+pub const detect = @import("detect.zig");
 
 // Only import parallel module on platforms that support threading
 const is_wasm = builtin.cpu.arch == .wasm32 or builtin.cpu.arch == .wasm64;
@@ -1477,6 +1478,28 @@ export fn csv_detect_bom(data_ptr: [*c]const u8, data_len: usize) usize {
         return detected.bom_len;
     }
     return 0;
+}
+
+/// Detect the most likely delimiter in CSV data.
+/// candidates_ptr: pointer to array of candidate delimiter bytes (ignored if num_candidates=0)
+/// num_candidates: number of candidates (0 to use defaults: comma, tab, pipe, semicolon)
+/// quote_char: the quote character to use during detection
+/// Returns the detected delimiter byte.
+export fn csv_detect_delimiter(
+    data_ptr: [*c]const u8,
+    data_len: usize,
+    candidates_ptr: [*c]const u8,
+    num_candidates: usize,
+    quote_char: u8,
+) u8 {
+    const data = data_ptr[0..data_len];
+    const candidates = if (num_candidates > 0)
+        candidates_ptr[0..num_candidates]
+    else
+        &detect.DEFAULT_CANDIDATES;
+
+    const result = detect.detectDelimiter(data, candidates, quote_char);
+    return result.delimiter;
 }
 
 // ============================================================================

--- a/test/unit/comments.test.ts
+++ b/test/unit/comments.test.ts
@@ -1,0 +1,149 @@
+/**
+ * Tests for Issue #4: Comment line support
+ */
+
+import { describe, test, expect, beforeAll } from "bun:test";
+import { CSVParser } from "../../src/ts/parser";
+import { writeFileSync } from "fs";
+import { join } from "path";
+
+const TEST_DIR = join(import.meta.dir, "..", "fixtures");
+
+beforeAll(() => {
+  writeFileSync(
+    join(TEST_DIR, "with-hash-comments.csv"),
+    "name,age,city\n# This is a comment\nAlice,30,NYC\n# Another comment\nBob,25,LA\n"
+  );
+
+  writeFileSync(
+    join(TEST_DIR, "with-semicolon-comments.csv"),
+    "name,age\n; comment line\nAlice,30\nBob,25\n"
+  );
+
+  writeFileSync(
+    join(TEST_DIR, "comments-only.csv"),
+    "name,age\n# comment 1\n# comment 2\n# comment 3\n"
+  );
+
+  writeFileSync(
+    join(TEST_DIR, "no-comments.csv"),
+    "name,age\nAlice,30\nBob,25\n"
+  );
+
+  writeFileSync(
+    join(TEST_DIR, "comment-in-field.csv"),
+    'name,note\nAlice,"# not a comment"\nBob,normal\n'
+  );
+});
+
+describe("Comment support", () => {
+  test("skips # comment lines when comments=true", () => {
+    const parser = new CSVParser(join(TEST_DIR, "with-hash-comments.csv"), {
+      comments: true,
+    });
+    const rows: Record<string, string | null>[] = [];
+
+    for (const row of parser) {
+      rows.push(row.toObject());
+    }
+    parser.close();
+
+    expect(rows.length).toBe(2);
+    expect(rows[0]?.name).toBe("Alice");
+    expect(rows[1]?.name).toBe("Bob");
+  });
+
+  test("skips custom comment character", () => {
+    const parser = new CSVParser(join(TEST_DIR, "with-semicolon-comments.csv"), {
+      comments: ";",
+    });
+    const rows: Record<string, string | null>[] = [];
+
+    for (const row of parser) {
+      rows.push(row.toObject());
+    }
+    parser.close();
+
+    expect(rows.length).toBe(2);
+    expect(rows[0]?.name).toBe("Alice");
+    expect(rows[1]?.name).toBe("Bob");
+  });
+
+  test("all comment lines results in no data rows", () => {
+    const parser = new CSVParser(join(TEST_DIR, "comments-only.csv"), {
+      comments: true,
+    });
+    const rows: Record<string, string | null>[] = [];
+
+    for (const row of parser) {
+      rows.push(row.toObject());
+    }
+    parser.close();
+
+    expect(rows.length).toBe(0);
+  });
+
+  test("does not skip comments when comments=false (default)", () => {
+    const parser = new CSVParser(join(TEST_DIR, "with-hash-comments.csv"));
+    let rowCount = 0;
+
+    for (const row of parser) {
+      rowCount++;
+    }
+    parser.close();
+
+    // Without comments option, # lines are treated as data
+    expect(rowCount).toBeGreaterThan(2);
+  });
+
+  test("does not affect file without comments", () => {
+    const parser = new CSVParser(join(TEST_DIR, "no-comments.csv"), {
+      comments: true,
+    });
+    const rows: Record<string, string | null>[] = [];
+
+    for (const row of parser) {
+      rows.push(row.toObject());
+    }
+    parser.close();
+
+    expect(rows.length).toBe(2);
+    expect(rows[0]?.name).toBe("Alice");
+  });
+
+  test("comments work with buffer input", () => {
+    const data = new TextEncoder().encode(
+      "name,age\n# skip this\nAlice,30\n# skip that\nBob,25\n"
+    );
+    const parser = new CSVParser(data, { comments: true });
+    const rows: Record<string, string | null>[] = [];
+
+    for (const row of parser) {
+      rows.push(row.toObject());
+    }
+    parser.close();
+
+    expect(rows.length).toBe(2);
+    expect(rows[0]?.name).toBe("Alice");
+    expect(rows[1]?.name).toBe("Bob");
+  });
+
+  test("comments combined with custom delimiter", () => {
+    const data = new TextEncoder().encode(
+      "name\tage\n# comment\nAlice\t30\nBob\t25\n"
+    );
+    const parser = new CSVParser(data, {
+      delimiter: "\t",
+      comments: "#",
+    });
+    const rows: Record<string, string | null>[] = [];
+
+    for (const row of parser) {
+      rows.push(row.toObject());
+    }
+    parser.close();
+
+    expect(rows.length).toBe(2);
+    expect(rows[0]?.name).toBe("Alice");
+  });
+});

--- a/test/unit/config-wiring.test.ts
+++ b/test/unit/config-wiring.test.ts
@@ -1,0 +1,248 @@
+/**
+ * Tests for Issue #2: Wire existing Zig config options through FFI
+ * Tests: delimiter, escapeChar, skipEmptyRows passing through FFI
+ */
+
+import { describe, test, expect, beforeAll } from "bun:test";
+import { CSVParser } from "../../src/ts/parser";
+import { writeFileSync } from "fs";
+import { join } from "path";
+
+const TEST_DIR = join(import.meta.dir, "..", "fixtures");
+
+beforeAll(() => {
+  // Tab-delimited file
+  writeFileSync(
+    join(TEST_DIR, "tab-delimited.csv"),
+    "name\tage\tcity\nAlice\t30\tNYC\nBob\t25\tLA\n"
+  );
+
+  // Pipe-delimited file
+  writeFileSync(
+    join(TEST_DIR, "pipe-delimited.csv"),
+    "name|age|city\nAlice|30|NYC\nBob|25|LA\n"
+  );
+
+  // Semicolon-delimited file
+  writeFileSync(
+    join(TEST_DIR, "semicolon-delimited.csv"),
+    "name;age;city\nAlice;30;NYC\nBob;25;LA\n"
+  );
+
+  // File with empty rows
+  writeFileSync(
+    join(TEST_DIR, "empty-rows.csv"),
+    "name,age,city\nAlice,30,NYC\n\n\nBob,25,LA\n\nCharlie,35,Chicago\n"
+  );
+
+  // File that is only empty rows
+  writeFileSync(
+    join(TEST_DIR, "all-empty-rows.csv"),
+    "name,age\n\n\n\n"
+  );
+
+  // File with custom escape char (backslash-escaped quotes)
+  writeFileSync(
+    join(TEST_DIR, "custom-escape.csv"),
+    'name,note\nAlice,"says \\"hello\\""\nBob,normal\n'
+  );
+});
+
+describe("Custom delimiter", () => {
+  test("parses tab-delimited file", () => {
+    const parser = new CSVParser(join(TEST_DIR, "tab-delimited.csv"), {
+      delimiter: "\t",
+    });
+    const rows: Record<string, string | null>[] = [];
+
+    for (const row of parser) {
+      rows.push(row.toObject());
+    }
+    parser.close();
+
+    expect(rows.length).toBe(2);
+    expect(rows[0]?.name).toBe("Alice");
+    expect(rows[0]?.age).toBe("30");
+    expect(rows[0]?.city).toBe("NYC");
+    expect(rows[1]?.name).toBe("Bob");
+  });
+
+  test("parses pipe-delimited file", () => {
+    const parser = new CSVParser(join(TEST_DIR, "pipe-delimited.csv"), {
+      delimiter: "|",
+    });
+    const rows: Record<string, string | null>[] = [];
+
+    for (const row of parser) {
+      rows.push(row.toObject());
+    }
+    parser.close();
+
+    expect(rows.length).toBe(2);
+    expect(rows[0]?.name).toBe("Alice");
+    expect(rows[0]?.age).toBe("30");
+  });
+
+  test("parses semicolon-delimited file", () => {
+    const parser = new CSVParser(join(TEST_DIR, "semicolon-delimited.csv"), {
+      delimiter: ";",
+    });
+    const rows: Record<string, string | null>[] = [];
+
+    for (const row of parser) {
+      rows.push(row.toObject());
+    }
+    parser.close();
+
+    expect(rows.length).toBe(2);
+    expect(rows[0]?.name).toBe("Alice");
+    expect(rows[1]?.city).toBe("LA");
+  });
+
+  test("delimiter works with buffer input", () => {
+    const data = new TextEncoder().encode(
+      "name\tage\nAlice\t30\nBob\t25\n"
+    );
+    const parser = new CSVParser(data, { delimiter: "\t" });
+    const rows: Record<string, string | null>[] = [];
+
+    for (const row of parser) {
+      rows.push(row.toObject());
+    }
+    parser.close();
+
+    expect(rows.length).toBe(2);
+    expect(rows[0]?.name).toBe("Alice");
+    expect(rows[0]?.age).toBe("30");
+  });
+});
+
+describe("Skip empty rows", () => {
+  test("skips empty rows by default", () => {
+    const parser = new CSVParser(join(TEST_DIR, "empty-rows.csv"));
+    const rows: Record<string, string | null>[] = [];
+
+    for (const row of parser) {
+      rows.push(row.toObject());
+    }
+    parser.close();
+
+    expect(rows.length).toBe(3);
+    expect(rows[0]?.name).toBe("Alice");
+    expect(rows[1]?.name).toBe("Bob");
+    expect(rows[2]?.name).toBe("Charlie");
+  });
+
+  test("includes empty rows when skipEmptyRows is false", () => {
+    const parser = new CSVParser(join(TEST_DIR, "empty-rows.csv"), {
+      skipEmptyRows: false,
+    });
+    let rowCount = 0;
+
+    for (const row of parser) {
+      rowCount++;
+    }
+    parser.close();
+
+    // Should include the empty rows now (3 data + 3 empty = 6)
+    expect(rowCount).toBeGreaterThan(3);
+  });
+
+  test("handles file with only empty rows", () => {
+    const parser = new CSVParser(join(TEST_DIR, "all-empty-rows.csv"));
+    const rows: Record<string, string | null>[] = [];
+
+    for (const row of parser) {
+      rows.push(row.toObject());
+    }
+    parser.close();
+
+    expect(rows.length).toBe(0);
+  });
+
+  test("skipEmptyRows works with buffer input", () => {
+    const data = new TextEncoder().encode("a,b\n1,2\n\n3,4\n");
+    const parser = new CSVParser(data, { skipEmptyRows: true });
+    const rows: Record<string, string | null>[] = [];
+
+    for (const row of parser) {
+      rows.push(row.toObject());
+    }
+    parser.close();
+
+    expect(rows.length).toBe(2);
+    expect(rows[0]?.a).toBe("1");
+    expect(rows[1]?.a).toBe("3");
+  });
+});
+
+describe("Escape character", () => {
+  test("accepts escapeChar option without error", () => {
+    const parser = new CSVParser(join(TEST_DIR, "tab-delimited.csv"), {
+      delimiter: "\t",
+      escapeChar: '"',
+    });
+    const rows: Record<string, string | null>[] = [];
+
+    for (const row of parser) {
+      rows.push(row.toObject());
+    }
+    parser.close();
+
+    expect(rows.length).toBe(2);
+    expect(rows[0]?.name).toBe("Alice");
+  });
+
+  test("defaults escapeChar to quoteChar", () => {
+    const parser = new CSVParser(join(TEST_DIR, "tab-delimited.csv"), {
+      delimiter: "\t",
+      quoteChar: "'",
+    });
+
+    // Should not throw - escapeChar defaults to quoteChar ("'")
+    const rows: Record<string, string | null>[] = [];
+    for (const row of parser) {
+      rows.push(row.toObject());
+    }
+    parser.close();
+
+    expect(rows.length).toBe(2);
+  });
+});
+
+describe("Combined config options", () => {
+  test("delimiter + skipEmptyRows together", () => {
+    const data = new TextEncoder().encode(
+      "name\tage\nAlice\t30\n\nBob\t25\n"
+    );
+    const parser = new CSVParser(data, {
+      delimiter: "\t",
+      skipEmptyRows: true,
+    });
+    const rows: Record<string, string | null>[] = [];
+
+    for (const row of parser) {
+      rows.push(row.toObject());
+    }
+    parser.close();
+
+    expect(rows.length).toBe(2);
+    expect(rows[0]?.name).toBe("Alice");
+    expect(rows[1]?.name).toBe("Bob");
+  });
+
+  test("hasHeader=false returns all rows as arrays", () => {
+    const data = new TextEncoder().encode("Alice,30,NYC\nBob,25,LA\n");
+    const parser = new CSVParser(data, { hasHeader: false });
+
+    const rows: (string | null)[][] = [];
+    for (const row of parser) {
+      rows.push(row.toArray());
+    }
+    parser.close();
+
+    expect(rows.length).toBe(2);
+    expect(rows[0]?.[0]).toBe("Alice");
+    expect(rows[0]?.[1]).toBe("30");
+  });
+});

--- a/test/unit/delimiter-detect.test.ts
+++ b/test/unit/delimiter-detect.test.ts
@@ -1,0 +1,176 @@
+/**
+ * Tests for Issue #3: Delimiter auto-detection
+ */
+
+import { describe, test, expect, beforeAll } from "bun:test";
+import { CSVParser } from "../../src/ts/parser";
+import { writeFileSync } from "fs";
+import { join } from "path";
+
+const TEST_DIR = join(import.meta.dir, "..", "fixtures");
+
+beforeAll(() => {
+  writeFileSync(
+    join(TEST_DIR, "auto-comma.csv"),
+    "name,age,city\nAlice,30,NYC\nBob,25,LA\nCharlie,35,Chicago\n"
+  );
+
+  writeFileSync(
+    join(TEST_DIR, "auto-tab.csv"),
+    "name\tage\tcity\nAlice\t30\tNYC\nBob\t25\tLA\nCharlie\t35\tChicago\n"
+  );
+
+  writeFileSync(
+    join(TEST_DIR, "auto-pipe.csv"),
+    "name|age|city\nAlice|30|NYC\nBob|25|LA\nCharlie|35|Chicago\n"
+  );
+
+  writeFileSync(
+    join(TEST_DIR, "auto-semicolon.csv"),
+    "name;age;city\nAlice;30;NYC\nBob;25;LA\nCharlie;35;Chicago\n"
+  );
+
+  writeFileSync(
+    join(TEST_DIR, "auto-single-col.csv"),
+    "name\nAlice\nBob\nCharlie\n"
+  );
+});
+
+describe("Delimiter auto-detection", () => {
+  test("detects comma delimiter from file", () => {
+    const parser = new CSVParser(join(TEST_DIR, "auto-comma.csv"), {
+      delimiter: "auto",
+    });
+    const rows: Record<string, string | null>[] = [];
+
+    for (const row of parser) {
+      rows.push(row.toObject());
+    }
+    parser.close();
+
+    expect(rows.length).toBe(3);
+    expect(rows[0]?.name).toBe("Alice");
+    expect(rows[0]?.age).toBe("30");
+    expect(rows[0]?.city).toBe("NYC");
+  });
+
+  test("detects tab delimiter from file", () => {
+    const parser = new CSVParser(join(TEST_DIR, "auto-tab.csv"), {
+      delimiter: "auto",
+    });
+    const rows: Record<string, string | null>[] = [];
+
+    for (const row of parser) {
+      rows.push(row.toObject());
+    }
+    parser.close();
+
+    expect(rows.length).toBe(3);
+    expect(rows[0]?.name).toBe("Alice");
+    expect(rows[0]?.age).toBe("30");
+    expect(rows[0]?.city).toBe("NYC");
+  });
+
+  test("detects pipe delimiter from file", () => {
+    const parser = new CSVParser(join(TEST_DIR, "auto-pipe.csv"), {
+      delimiter: "auto",
+    });
+    const rows: Record<string, string | null>[] = [];
+
+    for (const row of parser) {
+      rows.push(row.toObject());
+    }
+    parser.close();
+
+    expect(rows.length).toBe(3);
+    expect(rows[0]?.name).toBe("Alice");
+    expect(rows[0]?.city).toBe("NYC");
+  });
+
+  test("detects semicolon delimiter from file", () => {
+    const parser = new CSVParser(join(TEST_DIR, "auto-semicolon.csv"), {
+      delimiter: "auto",
+    });
+    const rows: Record<string, string | null>[] = [];
+
+    for (const row of parser) {
+      rows.push(row.toObject());
+    }
+    parser.close();
+
+    expect(rows.length).toBe(3);
+    expect(rows[0]?.name).toBe("Alice");
+    expect(rows[0]?.age).toBe("30");
+  });
+
+  test("detects delimiter from buffer input", () => {
+    const data = new TextEncoder().encode(
+      "name\tage\tcity\nAlice\t30\tNYC\nBob\t25\tLA\n"
+    );
+    const parser = new CSVParser(data, { delimiter: "auto" });
+    const rows: Record<string, string | null>[] = [];
+
+    for (const row of parser) {
+      rows.push(row.toObject());
+    }
+    parser.close();
+
+    expect(rows.length).toBe(2);
+    expect(rows[0]?.name).toBe("Alice");
+    expect(rows[0]?.age).toBe("30");
+  });
+
+  test("falls back to comma for single-column file", () => {
+    const parser = new CSVParser(join(TEST_DIR, "auto-single-col.csv"), {
+      delimiter: "auto",
+    });
+    const rows: Record<string, string | null>[] = [];
+
+    for (const row of parser) {
+      rows.push(row.toObject());
+    }
+    parser.close();
+
+    // Single-column: detection falls back to comma, parses as 1 field per row
+    expect(rows.length).toBe(3);
+    expect(rows[0]?.name).toBe("Alice");
+  });
+
+  test("delimitersToGuess limits candidates", () => {
+    // Data with semicolons, but only offer pipe and tab as guesses
+    const data = new TextEncoder().encode(
+      "name;age;city\nAlice;30;NYC\nBob;25;LA\n"
+    );
+    const parser = new CSVParser(data, {
+      delimiter: "auto",
+      delimitersToGuess: ["|", "\t"],
+    });
+    let rowCount = 0;
+
+    for (const row of parser) {
+      rowCount++;
+    }
+    parser.close();
+
+    // Neither pipe nor tab splits the data, so falls back to first candidate
+    // The data will be treated as single-field rows
+    expect(rowCount).toBeGreaterThan(0);
+  });
+
+  test("detects delimiter with quoted fields", () => {
+    const data = new TextEncoder().encode(
+      'name|note|city\nAlice|"hello|world"|NYC\nBob|normal|LA\n'
+    );
+    const parser = new CSVParser(data, { delimiter: "auto" });
+    const rows: Record<string, string | null>[] = [];
+
+    for (const row of parser) {
+      rows.push(row.toObject());
+    }
+    parser.close();
+
+    expect(rows.length).toBe(2);
+    expect(rows[0]?.name).toBe("Alice");
+    expect(rows[0]?.city).toBe("NYC");
+  });
+});


### PR DESCRIPTION
## Summary
- Adds `delimiter: "auto"` option for automatic delimiter detection, matching PapaParse's signature feature
- New `src/zig/detect.zig` module with scoring algorithm: samples first 10 rows, tests candidates (`,` `\t` `|` `;`), selects by field count consistency × average fields
- Handles quoted fields correctly during detection (respects `quoteChar`)
- `delimitersToGuess` option allows custom candidate list
- FFI export `csv_detect_delimiter` for native-speed detection
- Falls back to `,` when no delimiter produces >1 field (single-column data)
- 8 new tests covering all 4 default delimiters, buffer input, quoted fields, custom candidates, single-column fallback

Closes #3

## Test plan
- [x] Auto-detects comma from file
- [x] Auto-detects tab from file
- [x] Auto-detects pipe from file
- [x] Auto-detects semicolon from file
- [x] Auto-detects from buffer input
- [x] Falls back to comma for single-column files
- [x] `delimitersToGuess` limits candidate set
- [x] Handles quoted fields containing delimiter characters
- [x] All 28 existing tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)