### PR TITLE
feat: add standalone unparse() function

### DIFF
--- a/src/ts/ffi.ts
+++ b/src/ts/ffi.ts
@@ -38,6 +38,7 @@ export interface NativeLib {
     escapeChar: number,
     hasHeader: boolean,
     skipEmptyRows: boolean,
+    commentChar: number,
   ) => number | null;
   csv_init_buffer: (data: Uint8Array, len: number) => number | null;
   csv_init_buffer_with_config: (
@@ -48,6 +49,7 @@ export interface NativeLib {
     escapeChar: number,
     hasHeader: boolean,
     skipEmptyRows: boolean,
+    commentChar: number,
   ) => number | null;
   csv_next_row: (handle: number) => boolean;
   csv_get_field_count: (handle: number) => number;
@@ -177,7 +179,7 @@ export function loadNativeLibrary(): NativeLib {
       returns: FFIType.ptr,
     },
     csv_init_with_config: {
-      args: [FFIType.ptr, FFIType.u8, FFIType.u8, FFIType.u8, FFIType.bool, FFIType.bool],
+      args: [FFIType.ptr, FFIType.u8, FFIType.u8, FFIType.u8, FFIType.bool, FFIType.bool, FFIType.u8],
       returns: FFIType.ptr,
     },
     csv_init_buffer: {
@@ -185,7 +187,7 @@ export function loadNativeLibrary(): NativeLib {
       returns: FFIType.ptr,
     },
     csv_init_buffer_with_config: {
-      args: [FFIType.ptr, FFIType.u64, FFIType.u8, FFIType.u8, FFIType.u8, FFIType.bool, FFIType.bool],
+      args: [FFIType.ptr, FFIType.u64, FFIType.u8, FFIType.u8, FFIType.u8, FFIType.bool, FFIType.bool, FFIType.u8],
       returns: FFIType.ptr,
     },
     csv_next_row: {

--- a/src/ts/ffi.ts
+++ b/src/ts/ffi.ts
@@ -31,7 +31,24 @@ export const MAX_BATCH_FIELDS = 64;
 /** Native library symbols */
 export interface NativeLib {
   csv_init: (path: Uint8Array) => number | null;
+  csv_init_with_config: (
+    path: Uint8Array,
+    delimiter: number,
+    quoteChar: number,
+    escapeChar: number,
+    hasHeader: boolean,
+    skipEmptyRows: boolean,
+  ) => number | null;
   csv_init_buffer: (data: Uint8Array, len: number) => number | null;
+  csv_init_buffer_with_config: (
+    data: Uint8Array,
+    len: number,
+    delimiter: number,
+    quoteChar: number,
+    escapeChar: number,
+    hasHeader: boolean,
+    skipEmptyRows: boolean,
+  ) => number | null;
   csv_next_row: (handle: number) => boolean;
   csv_get_field_count: (handle: number) => number;
   csv_get_field_ptr: (handle: number, col: number) => number | null;
@@ -159,8 +176,16 @@ export function loadNativeLibrary(): NativeLib {
       args: [FFIType.ptr],
       returns: FFIType.ptr,
     },
+    csv_init_with_config: {
+      args: [FFIType.ptr, FFIType.u8, FFIType.u8, FFIType.u8, FFIType.bool, FFIType.bool],
+      returns: FFIType.ptr,
+    },
     csv_init_buffer: {
       args: [FFIType.ptr, FFIType.u64],
+      returns: FFIType.ptr,
+    },
+    csv_init_buffer_with_config: {
+      args: [FFIType.ptr, FFIType.u64, FFIType.u8, FFIType.u8, FFIType.u8, FFIType.bool, FFIType.bool],
       returns: FFIType.ptr,
     },
     csv_next_row: {

--- a/src/ts/index.ts
+++ b/src/ts/index.ts
@@ -8,6 +8,7 @@ export { CSVParser, type CSVParserOptions } from "./parser";
 export { CSVRow } from "./row";
 export { DataFrame, type DataFrameOptions } from "./dataframe";
 export { CSVWriter, ModificationLog, type CSVWriterOptions } from "./writer";
+export { unparse, type UnparseConfig } from "./unparse";
 export { loadNativeLibrary, isNativeAvailable } from "./ffi";
 export type {
   Schema,

--- a/src/ts/unparse.ts
+++ b/src/ts/unparse.ts
@@ -1,0 +1,163 @@
+/**
+ * unparse() - Convert data back to CSV string
+ *
+ * Compatible with PapaParse's Papa.unparse() API.
+ */
+
+/** Configuration for unparse */
+export interface UnparseConfig {
+  /** Field delimiter (default: ",") */
+  delimiter?: string;
+  /** Quote character (default: '"') */
+  quoteChar?: string;
+  /** Escape character for quotes inside fields (default: same as quoteChar, i.e. doubled) */
+  escapeChar?: string;
+  /** Whether to quote all fields, or a per-column boolean array */
+  quotes?: boolean | boolean[];
+  /** Whether to include header row when input is array of objects (default: true) */
+  header?: boolean;
+  /** Line ending (default: "\r\n") */
+  newline?: string;
+  /** Column names to include and their order. Only applies to object input. */
+  columns?: string[];
+  /** Skip empty lines in output (default: false) */
+  skipEmptyLines?: boolean;
+}
+
+/** PapaParse-style result object: { fields: string[], data: unknown[][] } */
+interface PapaResultShape {
+  fields: string[];
+  data: unknown[][];
+}
+
+/**
+ * Convert data to a CSV string.
+ *
+ * Accepts:
+ * - Array of arrays: `[["a","b"], [1,2]]`
+ * - Array of objects: `[{name:"Alice", age:30}]`
+ * - PapaParse result shape: `{ fields: ["name","age"], data: [["Alice",30]] }`
+ * - JSON string (auto-parsed)
+ */
+export function unparse(
+  data: unknown[][] | Record<string, unknown>[] | PapaResultShape | string,
+  config?: UnparseConfig,
+): string {
+  const delimiter = config?.delimiter ?? ",";
+  const quoteChar = config?.quoteChar ?? '"';
+  const escapeChar = config?.escapeChar ?? quoteChar;
+  const newline = config?.newline ?? "\r\n";
+  const includeHeader = config?.header ?? true;
+  const skipEmptyLines = config?.skipEmptyLines ?? false;
+  const quotes = config?.quotes;
+
+  // Parse JSON string input
+  let parsed: unknown[][] | Record<string, unknown>[] | PapaResultShape = data as any;
+  if (typeof data === "string") {
+    parsed = JSON.parse(data);
+  }
+
+  // Determine format and extract headers + rows
+  let headers: string[] | null = null;
+  let rows: unknown[][];
+
+  if (isPapaResult(parsed)) {
+    // PapaParse result shape: { fields, data }
+    headers = parsed.fields;
+    rows = parsed.data;
+  } else if (Array.isArray(parsed) && parsed.length > 0 && !Array.isArray(parsed[0]) && typeof parsed[0] === "object" && parsed[0] !== null) {
+    // Array of objects
+    const objects = parsed as Record<string, unknown>[];
+    if (config?.columns) {
+      headers = config.columns;
+    } else {
+      // Collect all unique keys in order of appearance
+      const keySet = new Set<string>();
+      for (const obj of objects) {
+        for (const key of Object.keys(obj)) {
+          keySet.add(key);
+        }
+      }
+      headers = Array.from(keySet);
+    }
+    rows = objects.map(obj => headers!.map(key => obj[key]));
+  } else {
+    // Array of arrays
+    rows = parsed as unknown[][];
+    headers = null;
+  }
+
+  const lines: string[] = [];
+
+  // Write header row
+  if (headers && includeHeader) {
+    lines.push(headers.map((h, i) => formatField(h, delimiter, quoteChar, escapeChar, quotes, i)).join(delimiter));
+  }
+
+  // Write data rows
+  for (const row of rows) {
+    if (!Array.isArray(row)) continue;
+
+    if (skipEmptyLines) {
+      const allEmpty = row.every(v => v === null || v === undefined || v === "");
+      if (allEmpty) continue;
+    }
+
+    lines.push(
+      row.map((val, i) => formatField(serializeValue(val), delimiter, quoteChar, escapeChar, quotes, i)).join(delimiter)
+    );
+  }
+
+  return lines.join(newline);
+}
+
+/** Serialize a value to string */
+function serializeValue(val: unknown): string {
+  if (val === null || val === undefined) return "";
+  if (val instanceof Date) return val.toISOString();
+  return String(val);
+}
+
+/** Format a single field, quoting if necessary */
+function formatField(
+  value: string,
+  delimiter: string,
+  quoteChar: string,
+  escapeChar: string,
+  quotes: boolean | boolean[] | undefined,
+  colIndex: number,
+): string {
+  // Determine if forced quoting is enabled for this column
+  const forceQuote = typeof quotes === "boolean"
+    ? quotes
+    : Array.isArray(quotes)
+      ? (quotes[colIndex] ?? false)
+      : false;
+
+  const needsQuote = forceQuote ||
+    value.includes(delimiter) ||
+    value.includes(quoteChar) ||
+    value.includes("\n") ||
+    value.includes("\r") ||
+    (value.length > 0 && (value[0] === " " || value[value.length - 1] === " "));
+
+  if (needsQuote) {
+    // Escape quote characters inside the value
+    const escaped = value.replaceAll(quoteChar, escapeChar + quoteChar);
+    return quoteChar + escaped + quoteChar;
+  }
+
+  return value;
+}
+
+/** Type guard for PapaParse result shape */
+function isPapaResult(data: unknown): data is PapaResultShape {
+  return (
+    typeof data === "object" &&
+    data !== null &&
+    "fields" in data &&
+    "data" in data &&
+    Array.isArray((data as PapaResultShape).fields) &&
+    Array.isArray((data as PapaResultShape).data)
+  );
+}

--- a/test/unit/comments.test.ts
+++ b/test/unit/comments.test.ts
@@ -1,0 +1,149 @@
+/**
+ * Tests for Issue #4: Comment line support
+ */
+
+import { describe, test, expect, beforeAll } from "bun:test";
+import { CSVParser } from "../../src/ts/parser";
+import { writeFileSync } from "fs";
+import { join } from "path";
+
+const TEST_DIR = join(import.meta.dir, "..", "fixtures");
+
+beforeAll(() => {
+  writeFileSync(
+    join(TEST_DIR, "with-hash-comments.csv"),
+    "name,age,city\n# This is a comment\nAlice,30,NYC\n# Another comment\nBob,25,LA\n"
+  );
+
+  writeFileSync(
+    join(TEST_DIR, "with-semicolon-comments.csv"),
+    "name,age\n; comment line\nAlice,30\nBob,25\n"
+  );
+
+  writeFileSync(
+    join(TEST_DIR, "comments-only.csv"),
+    "name,age\n# comment 1\n# comment 2\n# comment 3\n"
+  );
+
+  writeFileSync(
+    join(TEST_DIR, "no-comments.csv"),
+    "name,age\nAlice,30\nBob,25\n"
+  );
+
+  writeFileSync(
+    join(TEST_DIR, "comment-in-field.csv"),
+    'name,note\nAlice,"# not a comment"\nBob,normal\n'
+  );
+});
+
+describe("Comment support", () => {
+  test("skips # comment lines when comments=true", () => {
+    const parser = new CSVParser(join(TEST_DIR, "with-hash-comments.csv"), {
+      comments: true,
+    });
+    const rows: Record<string, string | null>[] = [];
+
+    for (const row of parser) {
+      rows.push(row.toObject());
+    }
+    parser.close();
+
+    expect(rows.length).toBe(2);
+    expect(rows[0]?.name).toBe("Alice");
+    expect(rows[1]?.name).toBe("Bob");
+  });
+
+  test("skips custom comment character", () => {
+    const parser = new CSVParser(join(TEST_DIR, "with-semicolon-comments.csv"), {
+      comments: ";",
+    });
+    const rows: Record<string, string | null>[] = [];
+
+    for (const row of parser) {
+      rows.push(row.toObject());
+    }
+    parser.close();
+
+    expect(rows.length).toBe(2);
+    expect(rows[0]?.name).toBe("Alice");
+    expect(rows[1]?.name).toBe("Bob");
+  });
+
+  test("all comment lines results in no data rows", () => {
+    const parser = new CSVParser(join(TEST_DIR, "comments-only.csv"), {
+      comments: true,
+    });
+    const rows: Record<string, string | null>[] = [];
+
+    for (const row of parser) {
+      rows.push(row.toObject());
+    }
+    parser.close();
+
+    expect(rows.length).toBe(0);
+  });
+
+  test("does not skip comments when comments=false (default)", () => {
+    const parser = new CSVParser(join(TEST_DIR, "with-hash-comments.csv"));
+    let rowCount = 0;
+
+    for (const row of parser) {
+      rowCount++;
+    }
+    parser.close();
+
+    // Without comments option, # lines are treated as data
+    expect(rowCount).toBeGreaterThan(2);
+  });
+
+  test("does not affect file without comments", () => {
+    const parser = new CSVParser(join(TEST_DIR, "no-comments.csv"), {
+      comments: true,
+    });
+    const rows: Record<string, string | null>[] = [];
+
+    for (const row of parser) {
+      rows.push(row.toObject());
+    }
+    parser.close();
+
+    expect(rows.length).toBe(2);
+    expect(rows[0]?.name).toBe("Alice");
+  });
+
+  test("comments work with buffer input", () => {
+    const data = new TextEncoder().encode(
+      "name,age\n# skip this\nAlice,30\n# skip that\nBob,25\n"
+    );
+    const parser = new CSVParser(data, { comments: true });
+    const rows: Record<string, string | null>[] = [];
+
+    for (const row of parser) {
+      rows.push(row.toObject());
+    }
+    parser.close();
+
+    expect(rows.length).toBe(2);
+    expect(rows[0]?.name).toBe("Alice");
+    expect(rows[1]?.name).toBe("Bob");
+  });
+
+  test("comments combined with custom delimiter", () => {
+    const data = new TextEncoder().encode(
+      "name\tage\n# comment\nAlice\t30\nBob\t25\n"
+    );
+    const parser = new CSVParser(data, {
+      delimiter: "\t",
+      comments: "#",
+    });
+    const rows: Record<string, string | null>[] = [];
+
+    for (const row of parser) {
+      rows.push(row.toObject());
+    }
+    parser.close();
+
+    expect(rows.length).toBe(2);
+    expect(rows[0]?.name).toBe("Alice");
+  });
+});

--- a/test/unit/config-wiring.test.ts
+++ b/test/unit/config-wiring.test.ts
@@ -1,0 +1,248 @@
+/**
+ * Tests for Issue #2: Wire existing Zig config options through FFI
+ * Tests: delimiter, escapeChar, skipEmptyRows passing through FFI
+ */
+
+import { describe, test, expect, beforeAll } from "bun:test";
+import { CSVParser } from "../../src/ts/parser";
+import { writeFileSync } from "fs";
+import { join } from "path";
+
+const TEST_DIR = join(import.meta.dir, "..", "fixtures");
+
+beforeAll(() => {
+  // Tab-delimited file
+  writeFileSync(
+    join(TEST_DIR, "tab-delimited.csv"),
+    "name\tage\tcity\nAlice\t30\tNYC\nBob\t25\tLA\n"
+  );
+
+  // Pipe-delimited file
+  writeFileSync(
+    join(TEST_DIR, "pipe-delimited.csv"),
+    "name|age|city\nAlice|30|NYC\nBob|25|LA\n"
+  );
+
+  // Semicolon-delimited file
+  writeFileSync(
+    join(TEST_DIR, "semicolon-delimited.csv"),
+    "name;age;city\nAlice;30;NYC\nBob;25;LA\n"
+  );
+
+  // File with empty rows
+  writeFileSync(
+    join(TEST_DIR, "empty-rows.csv"),
+    "name,age,city\nAlice,30,NYC\n\n\nBob,25,LA\n\nCharlie,35,Chicago\n"
+  );
+
+  // File that is only empty rows
+  writeFileSync(
+    join(TEST_DIR, "all-empty-rows.csv"),
+    "name,age\n\n\n\n"
+  );
+
+  // File with custom escape char (backslash-escaped quotes)
+  writeFileSync(
+    join(TEST_DIR, "custom-escape.csv"),
+    'name,note\nAlice,"says \\"hello\\""\nBob,normal\n'
+  );
+});
+
+describe("Custom delimiter", () => {
+  test("parses tab-delimited file", () => {
+    const parser = new CSVParser(join(TEST_DIR, "tab-delimited.csv"), {
+      delimiter: "\t",
+    });
+    const rows: Record<string, string | null>[] = [];
+
+    for (const row of parser) {
+      rows.push(row.toObject());
+    }
+    parser.close();
+
+    expect(rows.length).toBe(2);
+    expect(rows[0]?.name).toBe("Alice");
+    expect(rows[0]?.age).toBe("30");
+    expect(rows[0]?.city).toBe("NYC");
+    expect(rows[1]?.name).toBe("Bob");
+  });
+
+  test("parses pipe-delimited file", () => {
+    const parser = new CSVParser(join(TEST_DIR, "pipe-delimited.csv"), {
+      delimiter: "|",
+    });
+    const rows: Record<string, string | null>[] = [];
+
+    for (const row of parser) {
+      rows.push(row.toObject());
+    }
+    parser.close();
+
+    expect(rows.length).toBe(2);
+    expect(rows[0]?.name).toBe("Alice");
+    expect(rows[0]?.age).toBe("30");
+  });
+
+  test("parses semicolon-delimited file", () => {
+    const parser = new CSVParser(join(TEST_DIR, "semicolon-delimited.csv"), {
+      delimiter: ";",
+    });
+    const rows: Record<string, string | null>[] = [];
+
+    for (const row of parser) {
+      rows.push(row.toObject());
+    }
+    parser.close();
+
+    expect(rows.length).toBe(2);
+    expect(rows[0]?.name).toBe("Alice");
+    expect(rows[1]?.city).toBe("LA");
+  });
+
+  test("delimiter works with buffer input", () => {
+    const data = new TextEncoder().encode(
+      "name\tage\nAlice\t30\nBob\t25\n"
+    );
+    const parser = new CSVParser(data, { delimiter: "\t" });
+    const rows: Record<string, string | null>[] = [];
+
+    for (const row of parser) {
+      rows.push(row.toObject());
+    }
+    parser.close();
+
+    expect(rows.length).toBe(2);
+    expect(rows[0]?.name).toBe("Alice");
+    expect(rows[0]?.age).toBe("30");
+  });
+});
+
+describe("Skip empty rows", () => {
+  test("skips empty rows by default", () => {
+    const parser = new CSVParser(join(TEST_DIR, "empty-rows.csv"));
+    const rows: Record<string, string | null>[] = [];
+
+    for (const row of parser) {
+      rows.push(row.toObject());
+    }
+    parser.close();
+
+    expect(rows.length).toBe(3);
+    expect(rows[0]?.name).toBe("Alice");
+    expect(rows[1]?.name).toBe("Bob");
+    expect(rows[2]?.name).toBe("Charlie");
+  });
+
+  test("includes empty rows when skipEmptyRows is false", () => {
+    const parser = new CSVParser(join(TEST_DIR, "empty-rows.csv"), {
+      skipEmptyRows: false,
+    });
+    let rowCount = 0;
+
+    for (const row of parser) {
+      rowCount++;
+    }
+    parser.close();
+
+    // Should include the empty rows now (3 data + 3 empty = 6)
+    expect(rowCount).toBeGreaterThan(3);
+  });
+
+  test("handles file with only empty rows", () => {
+    const parser = new CSVParser(join(TEST_DIR, "all-empty-rows.csv"));
+    const rows: Record<string, string | null>[] = [];
+
+    for (const row of parser) {
+      rows.push(row.toObject());
+    }
+    parser.close();
+
+    expect(rows.length).toBe(0);
+  });
+
+  test("skipEmptyRows works with buffer input", () => {
+    const data = new TextEncoder().encode("a,b\n1,2\n\n3,4\n");
+    const parser = new CSVParser(data, { skipEmptyRows: true });
+    const rows: Record<string, string | null>[] = [];
+
+    for (const row of parser) {
+      rows.push(row.toObject());
+    }
+    parser.close();
+
+    expect(rows.length).toBe(2);
+    expect(rows[0]?.a).toBe("1");
+    expect(rows[1]?.a).toBe("3");
+  });
+});
+
+describe("Escape character", () => {
+  test("accepts escapeChar option without error", () => {
+    const parser = new CSVParser(join(TEST_DIR, "tab-delimited.csv"), {
+      delimiter: "\t",
+      escapeChar: '"',
+    });
+    const rows: Record<string, string | null>[] = [];
+
+    for (const row of parser) {
+      rows.push(row.toObject());
+    }
+    parser.close();
+
+    expect(rows.length).toBe(2);
+    expect(rows[0]?.name).toBe("Alice");
+  });
+
+  test("defaults escapeChar to quoteChar", () => {
+    const parser = new CSVParser(join(TEST_DIR, "tab-delimited.csv"), {
+      delimiter: "\t",
+      quoteChar: "'",
+    });
+
+    // Should not throw - escapeChar defaults to quoteChar ("'")
+    const rows: Record<string, string | null>[] = [];
+    for (const row of parser) {
+      rows.push(row.toObject());
+    }
+    parser.close();
+
+    expect(rows.length).toBe(2);
+  });
+});
+
+describe("Combined config options", () => {
+  test("delimiter + skipEmptyRows together", () => {
+    const data = new TextEncoder().encode(
+      "name\tage\nAlice\t30\n\nBob\t25\n"
+    );
+    const parser = new CSVParser(data, {
+      delimiter: "\t",
+      skipEmptyRows: true,
+    });
+    const rows: Record<string, string | null>[] = [];
+
+    for (const row of parser) {
+      rows.push(row.toObject());
+    }
+    parser.close();
+
+    expect(rows.length).toBe(2);
+    expect(rows[0]?.name).toBe("Alice");
+    expect(rows[1]?.name).toBe("Bob");
+  });
+
+  test("hasHeader=false returns all rows as arrays", () => {
+    const data = new TextEncoder().encode("Alice,30,NYC\nBob,25,LA\n");
+    const parser = new CSVParser(data, { hasHeader: false });
+
+    const rows: (string | null)[][] = [];
+    for (const row of parser) {
+      rows.push(row.toArray());
+    }
+    parser.close();
+
+    expect(rows.length).toBe(2);
+    expect(rows[0]?.[0]).toBe("Alice");
+    expect(rows[0]?.[1]).toBe("30");
+  });
+});

--- a/test/unit/unparse.test.ts
+++ b/test/unit/unparse.test.ts
@@ -1,0 +1,190 @@
+/**
+ * Tests for Issue #6: unparse() function
+ */
+
+import { describe, test, expect } from "bun:test";
+import { unparse } from "../../src/ts/unparse";
+
+describe("unparse - array of arrays", () => {
+  test("basic array of arrays", () => {
+    const result = unparse([
+      ["name", "age", "city"],
+      ["Alice", "30", "NYC"],
+      ["Bob", "25", "LA"],
+    ]);
+    expect(result).toBe("name,age,city\r\nAlice,30,NYC\r\nBob,25,LA");
+  });
+
+  test("single row", () => {
+    const result = unparse([["hello", "world"]]);
+    expect(result).toBe("hello,world");
+  });
+
+  test("empty input", () => {
+    const result = unparse([]);
+    expect(result).toBe("");
+  });
+});
+
+describe("unparse - array of objects", () => {
+  test("basic array of objects with header", () => {
+    const result = unparse([
+      { name: "Alice", age: 30, city: "NYC" },
+      { name: "Bob", age: 25, city: "LA" },
+    ]);
+    expect(result).toBe("name,age,city\r\nAlice,30,NYC\r\nBob,25,LA");
+  });
+
+  test("header=false omits header row", () => {
+    const result = unparse(
+      [
+        { name: "Alice", age: 30 },
+        { name: "Bob", age: 25 },
+      ],
+      { header: false },
+    );
+    expect(result).toBe("Alice,30\r\nBob,25");
+  });
+
+  test("columns option selects and orders fields", () => {
+    const result = unparse(
+      [
+        { name: "Alice", age: 30, city: "NYC" },
+        { name: "Bob", age: 25, city: "LA" },
+      ],
+      { columns: ["city", "name"] },
+    );
+    expect(result).toBe("city,name\r\nNYC,Alice\r\nLA,Bob");
+  });
+
+  test("handles missing keys as empty string", () => {
+    const result = unparse([
+      { name: "Alice", age: 30 },
+      { name: "Bob" },
+    ]);
+    expect(result).toBe("name,age\r\nAlice,30\r\nBob,");
+  });
+});
+
+describe("unparse - PapaParse result shape", () => {
+  test("accepts { fields, data } shape", () => {
+    const result = unparse({
+      fields: ["name", "age"],
+      data: [
+        ["Alice", "30"],
+        ["Bob", "25"],
+      ],
+    });
+    expect(result).toBe("name,age\r\nAlice,30\r\nBob,25");
+  });
+});
+
+describe("unparse - JSON string input", () => {
+  test("auto-parses JSON string", () => {
+    const json = JSON.stringify([
+      { name: "Alice", age: 30 },
+      { name: "Bob", age: 25 },
+    ]);
+    const result = unparse(json);
+    expect(result).toBe("name,age\r\nAlice,30\r\nBob,25");
+  });
+});
+
+describe("unparse - quoting", () => {
+  test("auto-quotes fields with delimiter", () => {
+    const result = unparse([["hello,world", "normal"]]);
+    expect(result).toBe('"hello,world",normal');
+  });
+
+  test("auto-quotes fields with newline", () => {
+    const result = unparse([["line1\nline2", "normal"]]);
+    expect(result).toBe('"line1\nline2",normal');
+  });
+
+  test("auto-quotes fields with quote char", () => {
+    const result = unparse([['say "hello"', "normal"]]);
+    expect(result).toBe('"say ""hello""",normal');
+  });
+
+  test("auto-quotes fields with leading/trailing spaces", () => {
+    const result = unparse([["  padded  ", "normal"]]);
+    expect(result).toBe('"  padded  ",normal');
+  });
+
+  test("quotes=true forces all fields to be quoted", () => {
+    const result = unparse(
+      [["Alice", "30"]],
+      { quotes: true },
+    );
+    expect(result).toBe('"Alice","30"');
+  });
+
+  test("quotes as per-column array", () => {
+    const result = unparse(
+      [["Alice", "30", "NYC"]],
+      { quotes: [true, false, true] },
+    );
+    expect(result).toBe('"Alice",30,"NYC"');
+  });
+});
+
+describe("unparse - config options", () => {
+  test("custom delimiter", () => {
+    const result = unparse(
+      [["Alice", "30"]],
+      { delimiter: "\t" },
+    );
+    expect(result).toBe("Alice\t30");
+  });
+
+  test("custom newline", () => {
+    const result = unparse(
+      [["a", "b"], ["c", "d"]],
+      { newline: "\n" },
+    );
+    expect(result).toBe("a,b\nc,d");
+  });
+
+  test("custom quoteChar", () => {
+    const result = unparse(
+      [["hello,world"]],
+      { quoteChar: "'" },
+    );
+    expect(result).toBe("'hello,world'");
+  });
+
+  test("skipEmptyLines removes empty rows", () => {
+    const result = unparse(
+      [
+        ["Alice", "30"],
+        ["", ""],
+        ["Bob", "25"],
+      ],
+      { skipEmptyLines: true },
+    );
+    expect(result).toBe("Alice,30\r\nBob,25");
+  });
+});
+
+describe("unparse - special values", () => {
+  test("null and undefined become empty string", () => {
+    const result = unparse([[null, undefined, "hello"]]);
+    expect(result).toBe(",,hello");
+  });
+
+  test("Date objects become ISO strings", () => {
+    const date = new Date("2024-01-15T10:30:00.000Z");
+    const result = unparse([[date, "event"]]);
+    expect(result).toBe("2024-01-15T10:30:00.000Z,event");
+  });
+
+  test("numbers are stringified", () => {
+    const result = unparse([[42, 3.14, -1]]);
+    expect(result).toBe("42,3.14,-1");
+  });
+
+  test("booleans are stringified", () => {
+    const result = unparse([[true, false]]);
+    expect(result).toBe("true,false");
+  });
+});


### PR DESCRIPTION
## Summary
- Adds `unparse(data, config?)` function for converting data back to CSV strings, matching PapaParse's `Papa.unparse()` API
- Input formats: array of arrays, array of objects, `{ fields, data }` shape, or JSON string
- Config options: `delimiter`, `quoteChar`, `escapeChar`, `quotes` (boolean or per-column array), `header`, `newline`, `columns`, `skipEmptyLines`
- Auto-quotes fields containing delimiter, quote char, newlines, or leading/trailing spaces
- Handles `null`/`undefined` as empty string, `Date` as ISO string
- Exported from `src/ts/index.ts`
- 23 new tests across 7 test groups

Closes #6

## Test plan
- [x] Array of arrays — basic, single row, empty
- [x] Array of objects — with header, without header, columns option, missing keys
- [x] PapaParse result shape `{ fields, data }`
- [x] JSON string input auto-parsing
- [x] Auto-quoting: delimiter, newlines, quotes, leading/trailing spaces
- [x] `quotes: true` and per-column quotes array
- [x] Custom delimiter, newline, quoteChar
- [x] skipEmptyLines
- [x] Special values: null, undefined, Date, numbers, booleans
- [x] All 28 existing tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)